### PR TITLE
Veneer: Separate out core/panel veneers

### DIFF
--- a/grafonnet-base/main.libsonnet
+++ b/grafonnet-base/main.libsonnet
@@ -15,7 +15,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       [schema.info.title]:
         (
           if 'PanelOptions' in schema.components.schemas[schema.info.title].properties
-          then root.panelLib.new(dashboardSchema, schema)
+          then root.panelLib.new(dashboardSchema, schema) + vaneer.panel(schema.info.title)
           else root.coreLib.new(schema)
         )
         + {
@@ -44,7 +44,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           'main.libsonnet',
         ),
     }
-    + veneer
+    + veneer.core
   ,
 
   docs(main):

--- a/grafonnet-base/veneer.libsonnet
+++ b/grafonnet-base/veneer.libsonnet
@@ -1,36 +1,18 @@
 {
-  dashboard+: {
+  core: {
+    dashboard+: {
+      new(title):
+        self.withTitle(title)
+        + self.withTimezone('utc')
+        + self.withTime('now-6h', 'now')
+      ,
+      withTime(from, to): self.time.withFrom(from) + self.time.withTo(to),
+    },
+  },
+
+  panel(type): {
     new(title):
       self.withTitle(title)
-      + self.withTimezone('utc')
-      + self.time.withFrom('now-6h')
-      + self.time.withTo('now'),
-
-    panels+: {
-      'dashboard.GraphPanel'+:: {},
-      graphPanel+: self['dashboard.GraphPanel'] {
-        new(title):
-          self.withTitle(title)
-          + self.withType('graph'),
-      },
-      'dashboard.HeatmapPanel'+:: {},
-      heatmapPanel+: self['dashboard.HeatmapPanel'] {
-        new(title):
-          self.withTitle(title)
-          + self.withType('heatmap'),
-      },
-      'dashboard.Panel'+:: {},
-      panel+: self['dashboard.Panel'] {
-        new(title, type):
-          self.withTitle(title)
-          + self.withType(type),
-      },
-      'dashboard.RowPanel'+:: {},
-      rowPanel+: self['dashboard.RowPanel'] {
-        new(title):
-          self.withTitle(title)
-          + self.withType(),
-      },
-    },
+      + self.withType(type),
   },
 }


### PR DESCRIPTION
This PR does two things:
* Makes separate veneers for panels and core (we want to add a `new()` method to every panel)
* Adds basic functions to dashboard veneer
