### PR TITLE
fix(prometheus): add functions for missing schema properties

### DIFF
--- a/grafonnet-base/veneer.libsonnet
+++ b/grafonnet-base/veneer.libsonnet
@@ -63,6 +63,14 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           uid: value,
         },
       },
+
+      withIntervalFactor(value): {
+        intervalFactor: value,
+      },
+
+      withLegendFormat(value): {
+        legendFormat: value,
+      },
     },
   },
 }


### PR DESCRIPTION
These disappeared with #13

I believe the `intervalFactor` is under discussion on whether it will stay in the future,
I'm pretty sure `legendFormat` is missing from the schema.