### PR TITLE
crdsonnet: Use hash not branch name

### DIFF
--- a/grafonnet-base/jsonnetfile.json
+++ b/grafonnet-base/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "crdsonnet"
         }
       },
-      "version": "duologic/merge_xofParts_in_object"
+      "version": "2a6ba69d9a92be43beebd1a554d8d87a28417e1f"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
Running `jb install` in the `examples/simple` directory, I get this error:
```
jb: error: failed to install packages: downloading: failed to create tmp dir: mkdir /home/malcolm/grafana/grafonnet/examples/simple/vendor/.tmp/jsonnetpkg-github.com-Duologic-crdsonnet-crdsonnet-duologic/merge_xofParts_in_object392534364: no such file or directory
```

My assumption is that this is because the branch name contains a slash. The simplest
immediate fix is to use a git SHA rather than a branch name. A better fix is to
merge the `crdsonnet` fix into `master`.
