### PR TITLE
crdsonnet: reference master

### DIFF
--- a/grafonnet-base/jsonnetfile.json
+++ b/grafonnet-base/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "crdsonnet"
         }
       },
-      "version": "149f4b090d3fa967de4652d1b5ee0f0e0664ebb3"
+      "version": "master"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
Required changes have been merged into `crdsonnet` `master`, so we need to
reference that now.
