### PR TITLE
refactor(base): veneer, type derivation and missing schema's

### DIFF
--- a/grafonnet-base/main.libsonnet
+++ b/grafonnet-base/main.libsonnet
@@ -17,31 +17,20 @@ local veneer = import './veneer/main.libsonnet';
     local filteredSchemas = {
       core: std.filterMap(
         function(schema)
-          !(
-            ('properties' in schema.components.schemas[schema.info.title])
-            && (
-              ('PanelOptions' in schema.components.schemas[schema.info.title].properties)
-              || ('PanelFieldConfig' in schema.components.schemas[schema.info.title].properties)
-            )
-          )
-          && !('DataQuery' in schema.components.schemas),
+          !std.endsWith(schema.info.title, 'PanelCfg')
+          && !std.endsWith(schema.info.title, 'DataQuery'),
         function(schema) root.restructure(schema),
         schemas
       ),
 
       panel: std.filterMap(
-        function(schema)
-          ('properties' in schema.components.schemas[schema.info.title])
-          && (
-            ('PanelOptions' in schema.components.schemas[schema.info.title].properties)
-            || ('PanelFieldConfig' in schema.components.schemas[schema.info.title].properties)
-          ),
+        function(schema) std.endsWith(schema.info.title, 'PanelCfg'),
         function(schema) root.restructure(schema),
         schemas
       ),
 
       query: std.filterMap(
-        function(schema) 'DataQuery' in schema.components.schemas,
+        function(schema) std.endsWith(schema.info.title, 'DataQuery'),
         function(schema) root.restructure(schema),
         schemas,
       ),

--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -1,7 +1,7 @@
 local util = import '../util/main.libsonnet';
 local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 
-{
+local veneer = {
   dashboard+: {
     // Remove legacy panels (heatmap, graph), new users should not create those.
     // Schemas are also underdeveloped.
@@ -17,7 +17,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       + self.time.withFrom('now-6h')
       + self.time.withTo('now'),
 
-    local withGraphTooltip = super.withGraphTooltip,
+    local withGraphTooltip = self.withGraphTooltip,
     graphTooltip+: {
       // 0 - Default
       // 1 - Shared crosshair
@@ -261,4 +261,6 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       panels: util.panel.setPanelIDs(self._panels),
     },
   },
-}
+};
+
+function(name) std.get(veneer, name, default={})

--- a/grafonnet-base/veneer/main.libsonnet
+++ b/grafonnet-base/veneer/main.libsonnet
@@ -1,41 +1,5 @@
-local main = import '../main.libsonnet';
-local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
-
 {
-  dashboard+: (import './dashboard.libsonnet').dashboard,
-  query+: (import './query.libsonnet').query,
-
-  // Move Row panel into panel subpackage
-  local panels = super.dashboard.panels,
-  panel+: {
-    row:
-      panels.RowPanel {
-        // Remove nested legacy panels as created by schema references.
-        panels:: {},
-
-        withType(): {
-          type: 'row',
-        },
-      }
-      + main.packageDocMixin('', 'row', 'panel.'),
-  },
-}
-+ {
-  panel+: {
-    [k]+: {
-      '#new':: d.func.new(
-        'Creates a new %s panel with a title.' % k,
-        args=[d.arg('title', d.T.string)]
-      ),
-      new(title):
-        self.withTitle(title)
-        + self.withType()
-        // Default to Mixed datasource so panels can be datasource agnostic, this
-        // requires query targets to explicitly set datasource, which is a lot more
-        // interesting from a reusability standpoint.
-        + self.datasource.withType('datasource')
-        + self.datasource.withUid('-- Mixed --'),
-    }
-    for k in std.objectFields(super.panel)
-  },
+  core: (import './core.libsonnet'),
+  panel: (import './panel.libsonnet'),
+  query: (import './query.libsonnet'),
 }

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -1,0 +1,16 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+function(name) {
+  '#new':: d.func.new(
+    'Creates a new %s panel with a title.' % name,
+    args=[d.arg('title', d.T.string)]
+  ),
+  new(title):
+    self.withTitle(title)
+    + self.withType()
+    // Default to Mixed datasource so panels can be datasource agnostic, this
+    // requires query targets to explicitly set datasource, which is a lot more
+    // interesting from a reusability standpoint.
+    + self.datasource.withType('datasource')
+    + self.datasource.withUid('-- Mixed --'),
+}

--- a/grafonnet-base/veneer/query.libsonnet
+++ b/grafonnet-base/veneer/query.libsonnet
@@ -17,75 +17,74 @@ local datasourceFunction(type) = {
     },
   },
 };
+local veneer = {
+  loki+:
+    {
+      '#new':: d.func.new(
+        'Creates a new loki query target for panels.',
+        args=[
+          d.arg('datasource', d.T.string),
+          d.arg('expr', d.T.string),
+        ]
+      ),
+      new(datasource, expr):
+        self.withDatasource(datasource)
+        + self.withExpr(expr),
 
-{
-  query+: {
-    loki+:
-      {
-        '#new':: d.func.new(
-          'Creates a new loki query target for panels.',
-          args=[
-            d.arg('datasource', d.T.string),
-            d.arg('expr', d.T.string),
-          ]
-        ),
-        new(datasource, expr):
-          self.withDatasource(datasource)
-          + self.withExpr(expr),
+    }
+    + datasourceFunction('loki'),
 
-      }
-      + datasourceFunction('loki'),
+  prometheus+:
+    {
+      '#new':: d.func.new(
+        'Creates a new prometheus query target for panels.',
+        args=[
+          d.arg('datasource', d.T.string),
+          d.arg('expr', d.T.string),
+        ]
+      ),
+      new(datasource, expr):
+        self.withDatasource(datasource)
+        + self.withExpr(expr),
 
-    prometheus+:
-      {
-        '#new':: d.func.new(
-          'Creates a new prometheus query target for panels.',
-          args=[
-            d.arg('datasource', d.T.string),
-            d.arg('expr', d.T.string),
-          ]
-        ),
-        new(datasource, expr):
-          self.withDatasource(datasource)
-          + self.withExpr(expr),
+      '#withIntervalFactor':: d.func.new(
+        'Set the interval factor for this query.',
+        args=[
+          d.arg('value', d.T.string),
+        ]
+      ),
+      withIntervalFactor(value): {
+        intervalFactor: value,
+      },
 
-        '#withIntervalFactor':: d.func.new(
-          'Set the interval factor for this query.',
-          args=[
-            d.arg('value', d.T.string),
-          ]
-        ),
-        withIntervalFactor(value): {
-          intervalFactor: value,
-        },
+      '#withLegendFormat':: d.func.new(
+        'Set the legend format for this query.',
+        args=[
+          d.arg('value', d.T.string),
+        ]
+      ),
+      withLegendFormat(value): {
+        legendFormat: value,
+      },
+    }
+    + datasourceFunction('prometheus'),
 
-        '#withLegendFormat':: d.func.new(
-          'Set the legend format for this query.',
-          args=[
-            d.arg('value', d.T.string),
-          ]
-        ),
-        withLegendFormat(value): {
-          legendFormat: value,
-        },
-      }
-      + datasourceFunction('prometheus'),
+  tempo+:
+    {
+      '#new':: d.func.new(
+        'Creates a new tempo query target for panels.',
+        args=[
+          d.arg('datasource', d.T.string),
+          d.arg('query', d.T.string),
+          d.arg('filters', d.T.array),
+        ]
+      ),
+      new(datasource, query, filters):
+        self.withDatasource(datasource)
+        + self.withQuery(query)
+        + self.withFilters(filters),
+    }
+    + datasourceFunction('tempo'),
+};
 
-    tempo+:
-      {
-        '#new':: d.func.new(
-          'Creates a new tempo query target for panels.',
-          args=[
-            d.arg('datasource', d.T.string),
-            d.arg('query', d.T.string),
-            d.arg('filters', d.T.array),
-          ]
-        ),
-        new(datasource, query, filters):
-          self.withDatasource(datasource)
-          + self.withQuery(query)
-          + self.withFilters(filters),
-      }
-      + datasourceFunction('tempo'),
-  },
-}
+function(name) std.get(veneer, name, default={})


### PR DESCRIPTION
Review tip: each commit can be reviewed separately.

refactor(base): take functional approach to adding veneer

The veneer was set up to squash everything on top, this functional approach takes a more
rigorous approach by injecting the veneer closer to the initialization of the original
code.

refactor(base): use schema.info.title to derive type

Previously the panel type schema's were characterized by PanelOptions and PanelFieldConfig
fields, these will change in the near future. Turns out deriving the type from the name is
equally consistent, I don't know why I didn't do that initially.

fix(base): provide backfilling of missing schemas

The referenced schema's are in fact empty and part of the `skipPlugins` list in Grafana,
newer version rendered by Grok will not include these schema's regardless of the
`skipPlugins` entry. This commit adds a bit of code that adds the missing plugins with
a generic schema so Grafonnet can keep feature parity with previous versions.