### PR TITLE
fix(docs): render mkdocs lists with proper indentation

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -1,8 +1,15 @@
 "docs_dir": "../docs/"
+"watch": 
+  - "../docs/grafonnet/"
+  - "../docs/README.md"
 "edit_uri": ""
+"use_directory_urls": false
 "markdown_extensions":
   - "pymdownx.highlight"
   - "pymdownx.superfences"
+  - "mdx_truly_sane_lists":
+      "nested_indent": 2
+      "truly_sane": True
 "plugins":
   - "search":
       "separator": "[\\s\\-\\.]+"

--- a/.mkdocs/requirements.txt
+++ b/.mkdocs/requirements.txt
@@ -6,3 +6,6 @@ mkdocs-minify-plugin>=0.3
 
 # Include the theme
 mkdocs-material>=7.1.6
+
+# Deal with list indent of 2 spaces
+mdx-truly-sane-lists>=1.3

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ localmkdocs:
 	python -m venv .mkdocs/.venv; \
 	source .mkdocs/.venv/bin/activate; \
 	pip install -r .mkdocs/requirements.txt; \
-	mkdocs build -f .mkdocs/mkdocs.yml
+	mkdocs serve -f .mkdocs/mkdocs.yml
 
 test:
 	@cd test/; \


### PR DESCRIPTION
The markdown files use a 2-space indentation for lists, the Python markdown parser expects
a 4-space indentation. This PR adds an extension that allows for 2-space indentation.


Additionally I noticed that the dashboard page redirected to the index page of the
subpackages, this PR enables an option to use the full urls rather than the directory
urls.