### PR TITLE
feat(veneer): provide clean dashboard API

### DIFF
--- a/docs/grafonnet/dashboard.md
+++ b/docs/grafonnet/dashboard.md
@@ -4,6 +4,8 @@ grafonnet.dashboard
 
 ## Subpackages
 
+* [annotation](dashboard/annotation.md)
+* [link](dashboard/link.md)
 * [variable](dashboard/variable.md)
 
 ## Index
@@ -14,9 +16,6 @@ grafonnet.dashboard
 * [`fn withDescription(value)`](#fn-withdescription)
 * [`fn withEditable(value=true)`](#fn-witheditable)
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
-* [`fn withGnetId(value)`](#fn-withgnetid)
-* [`fn withGraphTooltip(value=0)`](#fn-withgraphtooltip)
-* [`fn withId(value)`](#fn-withid)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
 * [`fn withLiveNow(value)`](#fn-withlivenow)
@@ -24,17 +23,12 @@ grafonnet.dashboard
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
 * [`fn withRefreshMixin(value)`](#fn-withrefreshmixin)
-* [`fn withRevision(value)`](#fn-withrevision)
 * [`fn withSchemaVersion(value=36)`](#fn-withschemaversion)
-* [`fn withSnapshot(value)`](#fn-withsnapshot)
-* [`fn withSnapshotMixin(value)`](#fn-withsnapshotmixin)
 * [`fn withStyle(value="dark")`](#fn-withstyle)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
 * [`fn withTemplating(value)`](#fn-withtemplating)
 * [`fn withTemplatingMixin(value)`](#fn-withtemplatingmixin)
-* [`fn withTime(value)`](#fn-withtime)
-* [`fn withTimeMixin(value)`](#fn-withtimemixin)
 * [`fn withTimepicker(value)`](#fn-withtimepicker)
 * [`fn withTimepickerMixin(value)`](#fn-withtimepickermixin)
 * [`fn withTimezone(value="browser")`](#fn-withtimezone)
@@ -42,60 +36,10 @@ grafonnet.dashboard
 * [`fn withUid(value)`](#fn-withuid)
 * [`fn withVariables(value)`](#fn-withvariables)
 * [`fn withVariablesMixin(value)`](#fn-withvariablesmixin)
-* [`fn withVersion(value)`](#fn-withversion)
 * [`fn withWeekStart(value)`](#fn-withweekstart)
-* [`obj annotations`](#obj-annotations)
-  * [`fn withList(value)`](#fn-annotationswithlist)
-  * [`fn withListMixin(value)`](#fn-annotationswithlistmixin)
-  * [`obj list`](#obj-annotationslist)
-    * [`fn withBuiltIn(value=0)`](#fn-annotationslistwithbuiltin)
-    * [`fn withDatasource(value)`](#fn-annotationslistwithdatasource)
-    * [`fn withDatasourceMixin(value)`](#fn-annotationslistwithdatasourcemixin)
-    * [`fn withEnable(value=true)`](#fn-annotationslistwithenable)
-    * [`fn withHide(value=false)`](#fn-annotationslistwithhide)
-    * [`fn withIconColor(value)`](#fn-annotationslistwithiconcolor)
-    * [`fn withName(value)`](#fn-annotationslistwithname)
-    * [`fn withRawQuery(value)`](#fn-annotationslistwithrawquery)
-    * [`fn withShowIn(value=0)`](#fn-annotationslistwithshowin)
-    * [`fn withTarget(value)`](#fn-annotationslistwithtarget)
-    * [`fn withTargetMixin(value)`](#fn-annotationslistwithtargetmixin)
-    * [`fn withType(value="dashboard")`](#fn-annotationslistwithtype)
-    * [`obj datasource`](#obj-annotationslistdatasource)
-      * [`fn withType(value)`](#fn-annotationslistdatasourcewithtype)
-      * [`fn withUid(value)`](#fn-annotationslistdatasourcewithuid)
-    * [`obj target`](#obj-annotationslisttarget)
-      * [`fn withLimit(value)`](#fn-annotationslisttargetwithlimit)
-      * [`fn withMatchAny(value)`](#fn-annotationslisttargetwithmatchany)
-      * [`fn withTags(value)`](#fn-annotationslisttargetwithtags)
-      * [`fn withTagsMixin(value)`](#fn-annotationslisttargetwithtagsmixin)
-      * [`fn withType(value)`](#fn-annotationslisttargetwithtype)
 * [`obj graphTooltip`](#obj-graphtooltip)
   * [`fn withSharedCrosshair()`](#fn-graphtooltipwithsharedcrosshair)
   * [`fn withSharedTooltip()`](#fn-graphtooltipwithsharedtooltip)
-* [`obj links`](#obj-links)
-  * [`fn withAsDropdown(value=false)`](#fn-linkswithasdropdown)
-  * [`fn withIcon(value)`](#fn-linkswithicon)
-  * [`fn withIncludeVars(value=false)`](#fn-linkswithincludevars)
-  * [`fn withKeepTime(value=false)`](#fn-linkswithkeeptime)
-  * [`fn withTags(value)`](#fn-linkswithtags)
-  * [`fn withTagsMixin(value)`](#fn-linkswithtagsmixin)
-  * [`fn withTargetBlank(value=false)`](#fn-linkswithtargetblank)
-  * [`fn withTitle(value)`](#fn-linkswithtitle)
-  * [`fn withTooltip(value)`](#fn-linkswithtooltip)
-  * [`fn withType(value)`](#fn-linkswithtype)
-  * [`fn withUrl(value)`](#fn-linkswithurl)
-* [`obj snapshot`](#obj-snapshot)
-  * [`fn withCreated(value)`](#fn-snapshotwithcreated)
-  * [`fn withExpires(value)`](#fn-snapshotwithexpires)
-  * [`fn withExternal(value)`](#fn-snapshotwithexternal)
-  * [`fn withExternalUrl(value)`](#fn-snapshotwithexternalurl)
-  * [`fn withId(value)`](#fn-snapshotwithid)
-  * [`fn withKey(value)`](#fn-snapshotwithkey)
-  * [`fn withName(value)`](#fn-snapshotwithname)
-  * [`fn withOrgId(value)`](#fn-snapshotwithorgid)
-  * [`fn withUpdated(value)`](#fn-snapshotwithupdated)
-  * [`fn withUrl(value)`](#fn-snapshotwithurl)
-  * [`fn withUserId(value)`](#fn-snapshotwithuserid)
 * [`obj time`](#obj-time)
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
@@ -124,7 +68,10 @@ Creates a new dashboard with a title.
 withAnnotations(value)
 ```
 
-TODO docs
+`withAnnotations` adds an array of annotations to a dashboard.
+
+This function appends passed data to existing values
+
 
 ### fn withAnnotationsMixin
 
@@ -132,7 +79,10 @@ TODO docs
 withAnnotationsMixin(value)
 ```
 
-TODO docs
+`withAnnotationsMixin` adds an array of annotations to a dashboard.
+
+This function appends passed data to existing values
+
 
 ### fn withDescription
 
@@ -157,35 +107,6 @@ withFiscalYearStartMonth(value=0)
 ```
 
 The month that the fiscal year starts on.  0 = January, 11 = December
-
-### fn withGnetId
-
-```ts
-withGnetId(value)
-```
-
-For dashboards imported from the https://grafana.com/grafana/dashboards/ portal
-
-### fn withGraphTooltip
-
-```ts
-withGraphTooltip(value=0)
-```
-
-0 for no shared crosshair or tooltip (default).
-1 for shared crosshair.
-2 for shared crosshair AND shared tooltip.
-
-Accepted values for `value` are 0, 1, 2
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-Unique numeric identifier for the dashboard.
-TODO must isolate or remove identifiers local to a Grafana instance...?
 
 ### fn withLinks
 
@@ -245,16 +166,6 @@ withRefreshMixin(value)
 
 Refresh rate of dashboard. Represented via interval string, e.g. "5s", "1m", "1h", "1d".
 
-### fn withRevision
-
-```ts
-withRevision(value)
-```
-
-This property should only be used in dashboards defined by plugins.  It is a quick check
-to see if the version has changed since the last time.  Unclear why using the version property
-is insufficient.
-
 ### fn withSchemaVersion
 
 ```ts
@@ -264,22 +175,6 @@ withSchemaVersion(value=36)
 Version of the JSON schema, incremented each time a Grafana update brings
 changes to said schema.
 TODO this is the existing schema numbering system. It will be replaced by Thema's themaVersion
-
-### fn withSnapshot
-
-```ts
-withSnapshot(value)
-```
-
-TODO docs
-
-### fn withSnapshotMixin
-
-```ts
-withSnapshotMixin(value)
-```
-
-TODO docs
 
 ### fn withStyle
 
@@ -322,22 +217,6 @@ withTemplatingMixin(value)
 ```
 
 TODO docs
-
-### fn withTime
-
-```ts
-withTime(value)
-```
-
-Time range for dashboard, e.g. last 6 hours, last 7 days, etc
-
-### fn withTimeMixin
-
-```ts
-withTimeMixin(value)
-```
-
-Time range for dashboard, e.g. last 6 hours, last 7 days, etc
 
 ### fn withTimepicker
 
@@ -401,14 +280,6 @@ withVariablesMixin(value)
 This function appends passed data to existing values
 
 
-### fn withVersion
-
-```ts
-withVersion(value)
-```
-
-Version of the dashboard, incremented each time the dashboard is updated.
-
 ### fn withWeekStart
 
 ```ts
@@ -416,186 +287,6 @@ withWeekStart(value)
 ```
 
 TODO docs
-
-### obj annotations
-
-
-#### fn annotations.withList
-
-```ts
-withList(value)
-```
-
-
-
-#### fn annotations.withListMixin
-
-```ts
-withListMixin(value)
-```
-
-
-
-#### obj annotations.list
-
-
-##### fn annotations.list.withBuiltIn
-
-```ts
-withBuiltIn(value=0)
-```
-
-
-
-##### fn annotations.list.withDatasource
-
-```ts
-withDatasource(value)
-```
-
-Datasource to use for annotation.
-
-##### fn annotations.list.withDatasourceMixin
-
-```ts
-withDatasourceMixin(value)
-```
-
-Datasource to use for annotation.
-
-##### fn annotations.list.withEnable
-
-```ts
-withEnable(value=true)
-```
-
-Whether annotation is enabled.
-
-##### fn annotations.list.withHide
-
-```ts
-withHide(value=false)
-```
-
-Whether to hide annotation.
-
-##### fn annotations.list.withIconColor
-
-```ts
-withIconColor(value)
-```
-
-Annotation icon color.
-
-##### fn annotations.list.withName
-
-```ts
-withName(value)
-```
-
-Name of annotation.
-
-##### fn annotations.list.withRawQuery
-
-```ts
-withRawQuery(value)
-```
-
-Query for annotation data.
-
-##### fn annotations.list.withShowIn
-
-```ts
-withShowIn(value=0)
-```
-
-
-
-##### fn annotations.list.withTarget
-
-```ts
-withTarget(value)
-```
-
-TODO docs
-
-##### fn annotations.list.withTargetMixin
-
-```ts
-withTargetMixin(value)
-```
-
-TODO docs
-
-##### fn annotations.list.withType
-
-```ts
-withType(value="dashboard")
-```
-
-
-
-##### obj annotations.list.datasource
-
-
-###### fn annotations.list.datasource.withType
-
-```ts
-withType(value)
-```
-
-
-
-###### fn annotations.list.datasource.withUid
-
-```ts
-withUid(value)
-```
-
-
-
-##### obj annotations.list.target
-
-
-###### fn annotations.list.target.withLimit
-
-```ts
-withLimit(value)
-```
-
-
-
-###### fn annotations.list.target.withMatchAny
-
-```ts
-withMatchAny(value)
-```
-
-
-
-###### fn annotations.list.target.withTags
-
-```ts
-withTags(value)
-```
-
-
-
-###### fn annotations.list.target.withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-
-
-###### fn annotations.list.target.withType
-
-```ts
-withType(value)
-```
-
-
 
 ### obj graphTooltip
 
@@ -615,190 +306,6 @@ withSharedTooltip()
 ```
 
 Share crosshair and tooltip on all panels.
-
-### obj links
-
-
-#### fn links.withAsDropdown
-
-```ts
-withAsDropdown(value=false)
-```
-
-
-
-#### fn links.withIcon
-
-```ts
-withIcon(value)
-```
-
-
-
-#### fn links.withIncludeVars
-
-```ts
-withIncludeVars(value=false)
-```
-
-
-
-#### fn links.withKeepTime
-
-```ts
-withKeepTime(value=false)
-```
-
-
-
-#### fn links.withTags
-
-```ts
-withTags(value)
-```
-
-
-
-#### fn links.withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-
-
-#### fn links.withTargetBlank
-
-```ts
-withTargetBlank(value=false)
-```
-
-
-
-#### fn links.withTitle
-
-```ts
-withTitle(value)
-```
-
-
-
-#### fn links.withTooltip
-
-```ts
-withTooltip(value)
-```
-
-
-
-#### fn links.withType
-
-```ts
-withType(value)
-```
-
-TODO docs
-
-Accepted values for `value` are "link", "dashboards"
-
-#### fn links.withUrl
-
-```ts
-withUrl(value)
-```
-
-
-
-### obj snapshot
-
-
-#### fn snapshot.withCreated
-
-```ts
-withCreated(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExpires
-
-```ts
-withExpires(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExternal
-
-```ts
-withExternal(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExternalUrl
-
-```ts
-withExternalUrl(value)
-```
-
-TODO docs
-
-#### fn snapshot.withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-#### fn snapshot.withKey
-
-```ts
-withKey(value)
-```
-
-TODO docs
-
-#### fn snapshot.withName
-
-```ts
-withName(value)
-```
-
-TODO docs
-
-#### fn snapshot.withOrgId
-
-```ts
-withOrgId(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUpdated
-
-```ts
-withUpdated(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUrl
-
-```ts
-withUrl(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUserId
-
-```ts
-withUserId(value)
-```
-
-TODO docs
 
 ### obj time
 

--- a/docs/grafonnet/dashboard.md
+++ b/docs/grafonnet/dashboard.md
@@ -29,8 +29,6 @@ grafonnet.dashboard
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
 * [`fn withTemplating(value)`](#fn-withtemplating)
 * [`fn withTemplatingMixin(value)`](#fn-withtemplatingmixin)
-* [`fn withTimepicker(value)`](#fn-withtimepicker)
-* [`fn withTimepickerMixin(value)`](#fn-withtimepickermixin)
 * [`fn withTimezone(value="browser")`](#fn-withtimezone)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withUid(value)`](#fn-withuid)
@@ -217,24 +215,6 @@ withTemplatingMixin(value)
 ```
 
 TODO docs
-
-### fn withTimepicker
-
-```ts
-withTimepicker(value)
-```
-
-TODO docs
-TODO this appears to be spread all over in the frontend. Concepts will likely need tidying in tandem with schema changes
-
-### fn withTimepickerMixin
-
-```ts
-withTimepickerMixin(value)
-```
-
-TODO docs
-TODO this appears to be spread all over in the frontend. Concepts will likely need tidying in tandem with schema changes
 
 ### fn withTimezone
 

--- a/docs/grafonnet/dashboard/annotation.md
+++ b/docs/grafonnet/dashboard/annotation.md
@@ -1,0 +1,187 @@
+# annotation
+
+
+
+## Index
+
+* [`fn withBuiltIn(value=0)`](#fn-withbuiltin)
+* [`fn withDatasource(value)`](#fn-withdatasource)
+* [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
+* [`fn withEnable(value=true)`](#fn-withenable)
+* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withIconColor(value)`](#fn-withiconcolor)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRawQuery(value)`](#fn-withrawquery)
+* [`fn withShowIn(value=0)`](#fn-withshowin)
+* [`fn withTarget(value)`](#fn-withtarget)
+* [`fn withTargetMixin(value)`](#fn-withtargetmixin)
+* [`fn withType(value="dashboard")`](#fn-withtype)
+* [`obj datasource`](#obj-datasource)
+  * [`fn withType(value)`](#fn-datasourcewithtype)
+  * [`fn withUid(value)`](#fn-datasourcewithuid)
+* [`obj target`](#obj-target)
+  * [`fn withLimit(value)`](#fn-targetwithlimit)
+  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withTags(value)`](#fn-targetwithtags)
+  * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
+  * [`fn withType(value)`](#fn-targetwithtype)
+
+## Fields
+
+### fn withBuiltIn
+
+```ts
+withBuiltIn(value=0)
+```
+
+
+
+### fn withDatasource
+
+```ts
+withDatasource(value)
+```
+
+Datasource to use for annotation.
+
+### fn withDatasourceMixin
+
+```ts
+withDatasourceMixin(value)
+```
+
+Datasource to use for annotation.
+
+### fn withEnable
+
+```ts
+withEnable(value=true)
+```
+
+Whether annotation is enabled.
+
+### fn withHide
+
+```ts
+withHide(value=false)
+```
+
+Whether to hide annotation.
+
+### fn withIconColor
+
+```ts
+withIconColor(value)
+```
+
+Annotation icon color.
+
+### fn withName
+
+```ts
+withName(value)
+```
+
+Name of annotation.
+
+### fn withRawQuery
+
+```ts
+withRawQuery(value)
+```
+
+Query for annotation data.
+
+### fn withShowIn
+
+```ts
+withShowIn(value=0)
+```
+
+
+
+### fn withTarget
+
+```ts
+withTarget(value)
+```
+
+TODO docs
+
+### fn withTargetMixin
+
+```ts
+withTargetMixin(value)
+```
+
+TODO docs
+
+### fn withType
+
+```ts
+withType(value="dashboard")
+```
+
+
+
+### obj datasource
+
+
+#### fn datasource.withType
+
+```ts
+withType(value)
+```
+
+
+
+#### fn datasource.withUid
+
+```ts
+withUid(value)
+```
+
+
+
+### obj target
+
+
+#### fn target.withLimit
+
+```ts
+withLimit(value)
+```
+
+
+
+#### fn target.withMatchAny
+
+```ts
+withMatchAny(value)
+```
+
+
+
+#### fn target.withTags
+
+```ts
+withTags(value)
+```
+
+
+
+#### fn target.withTagsMixin
+
+```ts
+withTagsMixin(value)
+```
+
+
+
+#### fn target.withType
+
+```ts
+withType(value)
+```
+
+

--- a/docs/grafonnet/dashboard/index.md
+++ b/docs/grafonnet/dashboard/index.md
@@ -1,3 +1,5 @@
 # grafonnet.dashboard
 
+* [annotation](annotation.md)
+* [link](link.md)
 * [variable](variable.md)

--- a/docs/grafonnet/dashboard/link.md
+++ b/docs/grafonnet/dashboard/link.md
@@ -1,0 +1,134 @@
+# link
+
+
+
+## Index
+
+* [`obj dashboards`](#obj-dashboards)
+  * [`fn new(title, tags)`](#fn-dashboardsnew)
+  * [`obj options`](#obj-dashboardsoptions)
+    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+* [`obj link`](#obj-link)
+  * [`fn new(title, utl)`](#fn-linknew)
+  * [`fn withIcon(value)`](#fn-linkwithicon)
+  * [`fn withTooltip(value)`](#fn-linkwithtooltip)
+  * [`obj options`](#obj-linkoptions)
+    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+
+## Fields
+
+### obj dashboards
+
+
+#### fn dashboards.new
+
+```ts
+new(title, tags)
+```
+
+Create links to dashboards based on `tags`.
+
+
+#### obj dashboards.options
+
+
+##### fn dashboards.options.withAsDropdown
+
+```ts
+withAsDropdown(value=false)
+```
+
+
+
+##### fn dashboards.options.withIncludeVars
+
+```ts
+withIncludeVars(value=false)
+```
+
+
+
+##### fn dashboards.options.withKeepTime
+
+```ts
+withKeepTime(value=false)
+```
+
+
+
+##### fn dashboards.options.withTargetBlank
+
+```ts
+withTargetBlank(value=false)
+```
+
+
+
+### obj link
+
+
+#### fn link.new
+
+```ts
+new(title, utl)
+```
+
+Create link to an arbitrary URL.
+
+
+#### fn link.withIcon
+
+```ts
+withIcon(value)
+```
+
+
+
+#### fn link.withTooltip
+
+```ts
+withTooltip(value)
+```
+
+
+
+#### obj link.options
+
+
+##### fn link.options.withAsDropdown
+
+```ts
+withAsDropdown(value=false)
+```
+
+
+
+##### fn link.options.withIncludeVars
+
+```ts
+withIncludeVars(value=false)
+```
+
+
+
+##### fn link.options.withKeepTime
+
+```ts
+withKeepTime(value=false)
+```
+
+
+
+##### fn link.options.withTargetBlank
+
+```ts
+withTargetBlank(value=false)
+```
+
+

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard.md
@@ -4,6 +4,8 @@ grafonnet.dashboard
 
 ## Subpackages
 
+* [annotation](dashboard/annotation.md)
+* [link](dashboard/link.md)
 * [variable](dashboard/variable.md)
 
 ## Index
@@ -14,9 +16,6 @@ grafonnet.dashboard
 * [`fn withDescription(value)`](#fn-withdescription)
 * [`fn withEditable(value=true)`](#fn-witheditable)
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
-* [`fn withGnetId(value)`](#fn-withgnetid)
-* [`fn withGraphTooltip(value=0)`](#fn-withgraphtooltip)
-* [`fn withId(value)`](#fn-withid)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
 * [`fn withLiveNow(value)`](#fn-withlivenow)
@@ -24,17 +23,12 @@ grafonnet.dashboard
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
 * [`fn withRefreshMixin(value)`](#fn-withrefreshmixin)
-* [`fn withRevision(value)`](#fn-withrevision)
 * [`fn withSchemaVersion(value=36)`](#fn-withschemaversion)
-* [`fn withSnapshot(value)`](#fn-withsnapshot)
-* [`fn withSnapshotMixin(value)`](#fn-withsnapshotmixin)
 * [`fn withStyle(value="dark")`](#fn-withstyle)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
 * [`fn withTemplating(value)`](#fn-withtemplating)
 * [`fn withTemplatingMixin(value)`](#fn-withtemplatingmixin)
-* [`fn withTime(value)`](#fn-withtime)
-* [`fn withTimeMixin(value)`](#fn-withtimemixin)
 * [`fn withTimepicker(value)`](#fn-withtimepicker)
 * [`fn withTimepickerMixin(value)`](#fn-withtimepickermixin)
 * [`fn withTimezone(value="browser")`](#fn-withtimezone)
@@ -42,60 +36,10 @@ grafonnet.dashboard
 * [`fn withUid(value)`](#fn-withuid)
 * [`fn withVariables(value)`](#fn-withvariables)
 * [`fn withVariablesMixin(value)`](#fn-withvariablesmixin)
-* [`fn withVersion(value)`](#fn-withversion)
 * [`fn withWeekStart(value)`](#fn-withweekstart)
-* [`obj annotations`](#obj-annotations)
-  * [`fn withList(value)`](#fn-annotationswithlist)
-  * [`fn withListMixin(value)`](#fn-annotationswithlistmixin)
-  * [`obj list`](#obj-annotationslist)
-    * [`fn withBuiltIn(value=0)`](#fn-annotationslistwithbuiltin)
-    * [`fn withDatasource(value)`](#fn-annotationslistwithdatasource)
-    * [`fn withDatasourceMixin(value)`](#fn-annotationslistwithdatasourcemixin)
-    * [`fn withEnable(value=true)`](#fn-annotationslistwithenable)
-    * [`fn withHide(value=false)`](#fn-annotationslistwithhide)
-    * [`fn withIconColor(value)`](#fn-annotationslistwithiconcolor)
-    * [`fn withName(value)`](#fn-annotationslistwithname)
-    * [`fn withRawQuery(value)`](#fn-annotationslistwithrawquery)
-    * [`fn withShowIn(value=0)`](#fn-annotationslistwithshowin)
-    * [`fn withTarget(value)`](#fn-annotationslistwithtarget)
-    * [`fn withTargetMixin(value)`](#fn-annotationslistwithtargetmixin)
-    * [`fn withType(value="dashboard")`](#fn-annotationslistwithtype)
-    * [`obj datasource`](#obj-annotationslistdatasource)
-      * [`fn withType(value)`](#fn-annotationslistdatasourcewithtype)
-      * [`fn withUid(value)`](#fn-annotationslistdatasourcewithuid)
-    * [`obj target`](#obj-annotationslisttarget)
-      * [`fn withLimit(value)`](#fn-annotationslisttargetwithlimit)
-      * [`fn withMatchAny(value)`](#fn-annotationslisttargetwithmatchany)
-      * [`fn withTags(value)`](#fn-annotationslisttargetwithtags)
-      * [`fn withTagsMixin(value)`](#fn-annotationslisttargetwithtagsmixin)
-      * [`fn withType(value)`](#fn-annotationslisttargetwithtype)
 * [`obj graphTooltip`](#obj-graphtooltip)
   * [`fn withSharedCrosshair()`](#fn-graphtooltipwithsharedcrosshair)
   * [`fn withSharedTooltip()`](#fn-graphtooltipwithsharedtooltip)
-* [`obj links`](#obj-links)
-  * [`fn withAsDropdown(value=false)`](#fn-linkswithasdropdown)
-  * [`fn withIcon(value)`](#fn-linkswithicon)
-  * [`fn withIncludeVars(value=false)`](#fn-linkswithincludevars)
-  * [`fn withKeepTime(value=false)`](#fn-linkswithkeeptime)
-  * [`fn withTags(value)`](#fn-linkswithtags)
-  * [`fn withTagsMixin(value)`](#fn-linkswithtagsmixin)
-  * [`fn withTargetBlank(value=false)`](#fn-linkswithtargetblank)
-  * [`fn withTitle(value)`](#fn-linkswithtitle)
-  * [`fn withTooltip(value)`](#fn-linkswithtooltip)
-  * [`fn withType(value)`](#fn-linkswithtype)
-  * [`fn withUrl(value)`](#fn-linkswithurl)
-* [`obj snapshot`](#obj-snapshot)
-  * [`fn withCreated(value)`](#fn-snapshotwithcreated)
-  * [`fn withExpires(value)`](#fn-snapshotwithexpires)
-  * [`fn withExternal(value)`](#fn-snapshotwithexternal)
-  * [`fn withExternalUrl(value)`](#fn-snapshotwithexternalurl)
-  * [`fn withId(value)`](#fn-snapshotwithid)
-  * [`fn withKey(value)`](#fn-snapshotwithkey)
-  * [`fn withName(value)`](#fn-snapshotwithname)
-  * [`fn withOrgId(value)`](#fn-snapshotwithorgid)
-  * [`fn withUpdated(value)`](#fn-snapshotwithupdated)
-  * [`fn withUrl(value)`](#fn-snapshotwithurl)
-  * [`fn withUserId(value)`](#fn-snapshotwithuserid)
 * [`obj time`](#obj-time)
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
@@ -124,7 +68,10 @@ Creates a new dashboard with a title.
 withAnnotations(value)
 ```
 
-TODO docs
+`withAnnotations` adds an array of annotations to a dashboard.
+
+This function appends passed data to existing values
+
 
 ### fn withAnnotationsMixin
 
@@ -132,7 +79,10 @@ TODO docs
 withAnnotationsMixin(value)
 ```
 
-TODO docs
+`withAnnotationsMixin` adds an array of annotations to a dashboard.
+
+This function appends passed data to existing values
+
 
 ### fn withDescription
 
@@ -157,35 +107,6 @@ withFiscalYearStartMonth(value=0)
 ```
 
 The month that the fiscal year starts on.  0 = January, 11 = December
-
-### fn withGnetId
-
-```ts
-withGnetId(value)
-```
-
-For dashboards imported from the https://grafana.com/grafana/dashboards/ portal
-
-### fn withGraphTooltip
-
-```ts
-withGraphTooltip(value=0)
-```
-
-0 for no shared crosshair or tooltip (default).
-1 for shared crosshair.
-2 for shared crosshair AND shared tooltip.
-
-Accepted values for `value` are 0, 1, 2
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-Unique numeric identifier for the dashboard.
-TODO must isolate or remove identifiers local to a Grafana instance...?
 
 ### fn withLinks
 
@@ -245,16 +166,6 @@ withRefreshMixin(value)
 
 Refresh rate of dashboard. Represented via interval string, e.g. "5s", "1m", "1h", "1d".
 
-### fn withRevision
-
-```ts
-withRevision(value)
-```
-
-This property should only be used in dashboards defined by plugins.  It is a quick check
-to see if the version has changed since the last time.  Unclear why using the version property
-is insufficient.
-
 ### fn withSchemaVersion
 
 ```ts
@@ -264,22 +175,6 @@ withSchemaVersion(value=36)
 Version of the JSON schema, incremented each time a Grafana update brings
 changes to said schema.
 TODO this is the existing schema numbering system. It will be replaced by Thema's themaVersion
-
-### fn withSnapshot
-
-```ts
-withSnapshot(value)
-```
-
-TODO docs
-
-### fn withSnapshotMixin
-
-```ts
-withSnapshotMixin(value)
-```
-
-TODO docs
 
 ### fn withStyle
 
@@ -322,22 +217,6 @@ withTemplatingMixin(value)
 ```
 
 TODO docs
-
-### fn withTime
-
-```ts
-withTime(value)
-```
-
-Time range for dashboard, e.g. last 6 hours, last 7 days, etc
-
-### fn withTimeMixin
-
-```ts
-withTimeMixin(value)
-```
-
-Time range for dashboard, e.g. last 6 hours, last 7 days, etc
 
 ### fn withTimepicker
 
@@ -401,14 +280,6 @@ withVariablesMixin(value)
 This function appends passed data to existing values
 
 
-### fn withVersion
-
-```ts
-withVersion(value)
-```
-
-Version of the dashboard, incremented each time the dashboard is updated.
-
 ### fn withWeekStart
 
 ```ts
@@ -416,186 +287,6 @@ withWeekStart(value)
 ```
 
 TODO docs
-
-### obj annotations
-
-
-#### fn annotations.withList
-
-```ts
-withList(value)
-```
-
-
-
-#### fn annotations.withListMixin
-
-```ts
-withListMixin(value)
-```
-
-
-
-#### obj annotations.list
-
-
-##### fn annotations.list.withBuiltIn
-
-```ts
-withBuiltIn(value=0)
-```
-
-
-
-##### fn annotations.list.withDatasource
-
-```ts
-withDatasource(value)
-```
-
-Datasource to use for annotation.
-
-##### fn annotations.list.withDatasourceMixin
-
-```ts
-withDatasourceMixin(value)
-```
-
-Datasource to use for annotation.
-
-##### fn annotations.list.withEnable
-
-```ts
-withEnable(value=true)
-```
-
-Whether annotation is enabled.
-
-##### fn annotations.list.withHide
-
-```ts
-withHide(value=false)
-```
-
-Whether to hide annotation.
-
-##### fn annotations.list.withIconColor
-
-```ts
-withIconColor(value)
-```
-
-Annotation icon color.
-
-##### fn annotations.list.withName
-
-```ts
-withName(value)
-```
-
-Name of annotation.
-
-##### fn annotations.list.withRawQuery
-
-```ts
-withRawQuery(value)
-```
-
-Query for annotation data.
-
-##### fn annotations.list.withShowIn
-
-```ts
-withShowIn(value=0)
-```
-
-
-
-##### fn annotations.list.withTarget
-
-```ts
-withTarget(value)
-```
-
-TODO docs
-
-##### fn annotations.list.withTargetMixin
-
-```ts
-withTargetMixin(value)
-```
-
-TODO docs
-
-##### fn annotations.list.withType
-
-```ts
-withType(value="dashboard")
-```
-
-
-
-##### obj annotations.list.datasource
-
-
-###### fn annotations.list.datasource.withType
-
-```ts
-withType(value)
-```
-
-
-
-###### fn annotations.list.datasource.withUid
-
-```ts
-withUid(value)
-```
-
-
-
-##### obj annotations.list.target
-
-
-###### fn annotations.list.target.withLimit
-
-```ts
-withLimit(value)
-```
-
-
-
-###### fn annotations.list.target.withMatchAny
-
-```ts
-withMatchAny(value)
-```
-
-
-
-###### fn annotations.list.target.withTags
-
-```ts
-withTags(value)
-```
-
-
-
-###### fn annotations.list.target.withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-
-
-###### fn annotations.list.target.withType
-
-```ts
-withType(value)
-```
-
-
 
 ### obj graphTooltip
 
@@ -615,190 +306,6 @@ withSharedTooltip()
 ```
 
 Share crosshair and tooltip on all panels.
-
-### obj links
-
-
-#### fn links.withAsDropdown
-
-```ts
-withAsDropdown(value=false)
-```
-
-
-
-#### fn links.withIcon
-
-```ts
-withIcon(value)
-```
-
-
-
-#### fn links.withIncludeVars
-
-```ts
-withIncludeVars(value=false)
-```
-
-
-
-#### fn links.withKeepTime
-
-```ts
-withKeepTime(value=false)
-```
-
-
-
-#### fn links.withTags
-
-```ts
-withTags(value)
-```
-
-
-
-#### fn links.withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-
-
-#### fn links.withTargetBlank
-
-```ts
-withTargetBlank(value=false)
-```
-
-
-
-#### fn links.withTitle
-
-```ts
-withTitle(value)
-```
-
-
-
-#### fn links.withTooltip
-
-```ts
-withTooltip(value)
-```
-
-
-
-#### fn links.withType
-
-```ts
-withType(value)
-```
-
-TODO docs
-
-Accepted values for `value` are "link", "dashboards"
-
-#### fn links.withUrl
-
-```ts
-withUrl(value)
-```
-
-
-
-### obj snapshot
-
-
-#### fn snapshot.withCreated
-
-```ts
-withCreated(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExpires
-
-```ts
-withExpires(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExternal
-
-```ts
-withExternal(value)
-```
-
-TODO docs
-
-#### fn snapshot.withExternalUrl
-
-```ts
-withExternalUrl(value)
-```
-
-TODO docs
-
-#### fn snapshot.withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-#### fn snapshot.withKey
-
-```ts
-withKey(value)
-```
-
-TODO docs
-
-#### fn snapshot.withName
-
-```ts
-withName(value)
-```
-
-TODO docs
-
-#### fn snapshot.withOrgId
-
-```ts
-withOrgId(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUpdated
-
-```ts
-withUpdated(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUrl
-
-```ts
-withUrl(value)
-```
-
-TODO docs
-
-#### fn snapshot.withUserId
-
-```ts
-withUserId(value)
-```
-
-TODO docs
 
 ### obj time
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard.md
@@ -29,8 +29,6 @@ grafonnet.dashboard
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
 * [`fn withTemplating(value)`](#fn-withtemplating)
 * [`fn withTemplatingMixin(value)`](#fn-withtemplatingmixin)
-* [`fn withTimepicker(value)`](#fn-withtimepicker)
-* [`fn withTimepickerMixin(value)`](#fn-withtimepickermixin)
 * [`fn withTimezone(value="browser")`](#fn-withtimezone)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withUid(value)`](#fn-withuid)
@@ -217,24 +215,6 @@ withTemplatingMixin(value)
 ```
 
 TODO docs
-
-### fn withTimepicker
-
-```ts
-withTimepicker(value)
-```
-
-TODO docs
-TODO this appears to be spread all over in the frontend. Concepts will likely need tidying in tandem with schema changes
-
-### fn withTimepickerMixin
-
-```ts
-withTimepickerMixin(value)
-```
-
-TODO docs
-TODO this appears to be spread all over in the frontend. Concepts will likely need tidying in tandem with schema changes
 
 ### fn withTimezone
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/annotation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/annotation.md
@@ -1,0 +1,187 @@
+# annotation
+
+
+
+## Index
+
+* [`fn withBuiltIn(value=0)`](#fn-withbuiltin)
+* [`fn withDatasource(value)`](#fn-withdatasource)
+* [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
+* [`fn withEnable(value=true)`](#fn-withenable)
+* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withIconColor(value)`](#fn-withiconcolor)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRawQuery(value)`](#fn-withrawquery)
+* [`fn withShowIn(value=0)`](#fn-withshowin)
+* [`fn withTarget(value)`](#fn-withtarget)
+* [`fn withTargetMixin(value)`](#fn-withtargetmixin)
+* [`fn withType(value="dashboard")`](#fn-withtype)
+* [`obj datasource`](#obj-datasource)
+  * [`fn withType(value)`](#fn-datasourcewithtype)
+  * [`fn withUid(value)`](#fn-datasourcewithuid)
+* [`obj target`](#obj-target)
+  * [`fn withLimit(value)`](#fn-targetwithlimit)
+  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withTags(value)`](#fn-targetwithtags)
+  * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
+  * [`fn withType(value)`](#fn-targetwithtype)
+
+## Fields
+
+### fn withBuiltIn
+
+```ts
+withBuiltIn(value=0)
+```
+
+
+
+### fn withDatasource
+
+```ts
+withDatasource(value)
+```
+
+Datasource to use for annotation.
+
+### fn withDatasourceMixin
+
+```ts
+withDatasourceMixin(value)
+```
+
+Datasource to use for annotation.
+
+### fn withEnable
+
+```ts
+withEnable(value=true)
+```
+
+Whether annotation is enabled.
+
+### fn withHide
+
+```ts
+withHide(value=false)
+```
+
+Whether to hide annotation.
+
+### fn withIconColor
+
+```ts
+withIconColor(value)
+```
+
+Annotation icon color.
+
+### fn withName
+
+```ts
+withName(value)
+```
+
+Name of annotation.
+
+### fn withRawQuery
+
+```ts
+withRawQuery(value)
+```
+
+Query for annotation data.
+
+### fn withShowIn
+
+```ts
+withShowIn(value=0)
+```
+
+
+
+### fn withTarget
+
+```ts
+withTarget(value)
+```
+
+TODO docs
+
+### fn withTargetMixin
+
+```ts
+withTargetMixin(value)
+```
+
+TODO docs
+
+### fn withType
+
+```ts
+withType(value="dashboard")
+```
+
+
+
+### obj datasource
+
+
+#### fn datasource.withType
+
+```ts
+withType(value)
+```
+
+
+
+#### fn datasource.withUid
+
+```ts
+withUid(value)
+```
+
+
+
+### obj target
+
+
+#### fn target.withLimit
+
+```ts
+withLimit(value)
+```
+
+
+
+#### fn target.withMatchAny
+
+```ts
+withMatchAny(value)
+```
+
+
+
+#### fn target.withTags
+
+```ts
+withTags(value)
+```
+
+
+
+#### fn target.withTagsMixin
+
+```ts
+withTagsMixin(value)
+```
+
+
+
+#### fn target.withType
+
+```ts
+withType(value)
+```
+
+

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/index.md
@@ -1,3 +1,5 @@
 # grafonnet.dashboard
 
+* [annotation](annotation.md)
+* [link](link.md)
 * [variable](variable.md)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/link.md
@@ -1,0 +1,134 @@
+# link
+
+
+
+## Index
+
+* [`obj dashboards`](#obj-dashboards)
+  * [`fn new(title, tags)`](#fn-dashboardsnew)
+  * [`obj options`](#obj-dashboardsoptions)
+    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+* [`obj link`](#obj-link)
+  * [`fn new(title, utl)`](#fn-linknew)
+  * [`fn withIcon(value)`](#fn-linkwithicon)
+  * [`fn withTooltip(value)`](#fn-linkwithtooltip)
+  * [`obj options`](#obj-linkoptions)
+    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+
+## Fields
+
+### obj dashboards
+
+
+#### fn dashboards.new
+
+```ts
+new(title, tags)
+```
+
+Create links to dashboards based on `tags`.
+
+
+#### obj dashboards.options
+
+
+##### fn dashboards.options.withAsDropdown
+
+```ts
+withAsDropdown(value=false)
+```
+
+
+
+##### fn dashboards.options.withIncludeVars
+
+```ts
+withIncludeVars(value=false)
+```
+
+
+
+##### fn dashboards.options.withKeepTime
+
+```ts
+withKeepTime(value=false)
+```
+
+
+
+##### fn dashboards.options.withTargetBlank
+
+```ts
+withTargetBlank(value=false)
+```
+
+
+
+### obj link
+
+
+#### fn link.new
+
+```ts
+new(title, utl)
+```
+
+Create link to an arbitrary URL.
+
+
+#### fn link.withIcon
+
+```ts
+withIcon(value)
+```
+
+
+
+#### fn link.withTooltip
+
+```ts
+withTooltip(value)
+```
+
+
+
+#### obj link.options
+
+
+##### fn link.options.withAsDropdown
+
+```ts
+withAsDropdown(value=false)
+```
+
+
+
+##### fn link.options.withIncludeVars
+
+```ts
+withIncludeVars(value=false)
+```
+
+
+
+##### fn link.options.withKeepTime
+
+```ts
+withKeepTime(value=false)
+```
+
+
+
+##### fn link.options.withTargetBlank
+
+```ts
+withTargetBlank(value=false)
+```
+
+

--- a/grafonnet-base/helpers.libsonnet
+++ b/grafonnet-base/helpers.libsonnet
@@ -1,0 +1,11 @@
+{
+  getAttributes(attributes, origin):
+    {
+      [n]: origin[n]
+      for n in attributes
+    }
+    + {
+      ['#' + n]: origin['#' + n]
+      for n in attributes
+    },
+}

--- a/grafonnet-base/veneer/annotation.libsonnet
+++ b/grafonnet-base/veneer/annotation.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+// The `anno` argument should match `dashboard.annotations.list`
+function(anno)
+  anno {
+    '#':: d.package.newSub(
+      'annotation',
+      '',
+    ),
+
+    // TODO: provide API that matches the UI
+  }

--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -17,7 +17,25 @@ local veneer = {
       + self.time.withFrom('now-6h')
       + self.time.withTo('now'),
 
-    local withGraphTooltip = self.withGraphTooltip,
+    // Hide functions covered by objects
+    '#withTime':: {},
+    '#withTimeMixin':: {},
+    '#withTimePicker':: {},
+    '#withTimePickerMixin':: {},
+    '#withGraphTooltip':: {},
+    '#withGraphTooltipMixin':: {},
+
+    // Hide internal values
+    '#withGnetId':: {},
+    '#withId':: {},
+    '#withRevision':: {},
+    '#withVersion':: {},
+    '#snapshot':: {},  // Snapshots can't be created through code afaik
+    '#withSnapshot':: {},
+    '#withSnapshotMixin':: {},
+
+
+    local withGraphTooltip = super.withGraphTooltip,
     graphTooltip+: {
       // 0 - Default
       // 1 - Shared crosshair

--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -20,8 +20,8 @@ local veneer = {
     // Hide functions covered by objects
     '#withTime':: {},
     '#withTimeMixin':: {},
-    '#withTimePicker':: {},
-    '#withTimePickerMixin':: {},
+    '#withTimepicker':: {},
+    '#withTimepickerMixin':: {},
     '#withGraphTooltip':: {},
     '#withGraphTooltipMixin':: {},
 

--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -35,7 +35,11 @@ local veneer = {
         withGraphTooltip(2),
     },
 
-    // Use manually written veneer to align with GUI
+    // Manual veneer for links (matches UI)
+    '#links':: {},
+    link: (import './link.libsonnet')(self.links),
+
+    // Manual veneer for variables (matches UI)
     variable: (import './variable.libsonnet')(self.templating.list),
 
     '#withVariables':

--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -35,6 +35,30 @@ local veneer = {
         withGraphTooltip(2),
     },
 
+    // Manual veneer for annotations
+    '#annotations':: {},
+    annotation: (import './annotation.libsonnet')(self.annotations.list),
+    '#withAnnotations':
+      d.func.new(
+        |||
+          `withAnnotations` adds an array of annotations to a dashboard.
+
+          This function appends passed data to existing values
+        |||,
+        args=[d.arg('value', d.T.array)]
+      ),
+    withAnnotations(value): self.annotations.withList(value),
+    '#withAnnotationsMixin':
+      d.func.new(
+        |||
+          `withAnnotationsMixin` adds an array of annotations to a dashboard.
+
+          This function appends passed data to existing values
+        |||,
+        args=[d.arg('value', d.T.array)]
+      ),
+    withAnnotationsMixin(value): self.annotations.withListMixin(value),
+
     // Manual veneer for links (matches UI)
     '#links':: {},
     link: (import './link.libsonnet')(self.links),

--- a/grafonnet-base/veneer/link.libsonnet
+++ b/grafonnet-base/veneer/link.libsonnet
@@ -1,0 +1,71 @@
+local helpers = import '../helpers.libsonnet';
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+// The `link` argument should match `dashboard.links`
+function(link) {
+
+  '#':: d.package.newSub(
+    'link',
+    '',
+  ),
+
+  local options =
+    {
+      options:
+        helpers.getAttributes(
+          [
+            'withAsDropdown',
+            'withKeepTime',
+            'withIncludeVars',
+            'withTargetBlank',
+          ],
+          link,
+        ),
+    },
+
+  local linkOptions =
+    helpers.getAttributes(
+      [
+        'withTooltip',
+        'withIcon',
+      ],
+      link,
+    ),
+
+  dashboards:
+    options {
+      '#new':: d.func.new(
+        |||
+          Create links to dashboards based on `tags`.
+        |||,
+        args=[
+          d.arg('title', d.T.string),
+          d.arg('tags', d.T.array),
+        ]
+      ),
+      new(title, tags):
+        link.withTitle(title)
+        + link.withType('dashboards')
+        + link.withTags(tags),
+    },
+
+  link:
+    options
+    + linkOptions
+    + {
+      '#new':: d.func.new(
+        |||
+          Create link to an arbitrary URL.
+        |||,
+        args=[
+          d.arg('title', d.T.string),
+          d.arg('utl', d.T.string),
+        ]
+      ),
+      new(title, url):
+        link.withTitle(title)
+        + link.withType('link')
+        + link.withUrl(url),
+    },
+
+}


### PR DESCRIPTION
This PR puts annotations and links into subpackages and hides a few functions that don't
seem relevant for creating dashboards through Grafonnet. This only hides it from the docs
but the functionality is still there.