### PR TITLE
Adding default value to row constructor.

### DIFF
--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -7,7 +7,7 @@ function(name) {
   ),
   new(title):
     self.withTitle(title)
-    + self.withType()
+    + self.withType('row')
     // Default to Mixed datasource so panels can be datasource agnostic, this
     // requires query targets to explicitly set datasource, which is a lot more
     // interesting from a reusability standpoint.


### PR DESCRIPTION
I ran into this issue while working with grafonnet, seems to be related to #49. This is probably just a quick fix, rather than a permanent one but allows us to workaround in the mean time.

> RUNTIME ERROR: Missing argument: value
        vendor/github.com/grafana/grafonnet/grafonnet-base/veneer/panel.libsonnet:10:7-22       function <anonymous>