### PR TITLE
docs(examples): add Terraform example

### DIFF
--- a/examples/terraform/.gitignore
+++ b/examples/terraform/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+.terraform.lock.hcl
+terraform.tfstate

--- a/examples/terraform/Makefile
+++ b/examples/terraform/Makefile
@@ -1,0 +1,6 @@
+.PHONY: apply
+apply:
+	@cd jsonnet/ && \
+		jb install && \
+		cd ../ && \
+		terraform apply

--- a/examples/terraform/dashboard.tf
+++ b/examples/terraform/dashboard.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    jsonnet = {
+      source  = "alxrem/jsonnet"
+      version = ">= 2.2.0"
+    }
+  }
+}
+
+provider "jsonnet" {
+  jsonnet_path = "${path.cwd}/jsonnet/vendor"
+}
+
+data "jsonnet_file" "dashboard" {
+  source = "${path.cwd}/jsonnet/main.libsonnet"
+}
+
+output "dashboard" {
+  value = data.jsonnet_file.dashboard.rendered
+}

--- a/examples/terraform/jsonnet/g.libsonnet
+++ b/examples/terraform/jsonnet/g.libsonnet
@@ -1,0 +1,1 @@
+import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet'

--- a/examples/terraform/jsonnet/jsonnetfile.json
+++ b/examples/terraform/jsonnet/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/examples/terraform/jsonnet/main.libsonnet
+++ b/examples/terraform/jsonnet/main.libsonnet
@@ -1,0 +1,17 @@
+local g = import 'g.libsonnet';
+
+g.dashboard.new('Faro dashboard')
++ g.dashboard.withDescription('Dashboard for Faro')
++ g.dashboard.graphTooltip.withSharedCrosshair()
++ g.dashboard.withPanels([
+  g.panel.timeSeries.new('Requests / sec')
+  + g.panel.timeSeries.withTargets([
+    g.query.prometheus.new(
+      'ops-cortex',
+      'sum by (status_code) (rate(request_duration_seconds_count{job=~".*/faro-api"}[$__rate_interval]))',
+    ),
+  ])
+  + g.panel.timeSeries.fieldConfig.defaults.withUnit('reqps')
+  + g.panel.timeSeries.gridPos.withW(24)
+  + g.panel.timeSeries.gridPos.withH(8),
+])


### PR DESCRIPTION
This PR adds an example for using the Jsonnet Terraform provider with Grafonnet.

ref: https://registry.terraform.io/providers/alxrem/jsonnet/latest/docs