### PR TITLE
fix(base): correctly deal with null mappings

### DIFF
--- a/docs/grafonnet/panel/alertGroups.md
+++ b/docs/grafonnet/panel/alertGroups.md
@@ -98,6 +98,10 @@ grafonnet.panel.alertGroups
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -758,3 +762,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/annotationsList.md
+++ b/docs/grafonnet/panel/annotationsList.md
@@ -106,6 +106,10 @@ grafonnet.panel.annotationsList
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -830,3 +834,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/barChart.md
+++ b/docs/grafonnet/panel/barChart.md
@@ -158,6 +158,10 @@ grafonnet.panel.barChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1290,3 +1294,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/barGauge.md
+++ b/docs/grafonnet/panel/barGauge.md
@@ -114,6 +114,10 @@ grafonnet.panel.barGauge
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -899,3 +903,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/candlestick.md
+++ b/docs/grafonnet/panel/candlestick.md
@@ -94,6 +94,10 @@ grafonnet.panel.candlestick
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -727,3 +731,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/canvas.md
+++ b/docs/grafonnet/panel/canvas.md
@@ -94,6 +94,10 @@ grafonnet.panel.canvas
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -727,3 +731,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/dashboardList.md
+++ b/docs/grafonnet/panel/dashboardList.md
@@ -105,6 +105,10 @@ grafonnet.panel.dashboardList
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -823,3 +827,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/debug.md
+++ b/docs/grafonnet/panel/debug.md
@@ -102,6 +102,10 @@ grafonnet.panel.debug
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -791,3 +795,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/gauge.md
+++ b/docs/grafonnet/panel/gauge.md
@@ -111,6 +111,10 @@ grafonnet.panel.gauge
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -867,3 +871,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/geomap.md
+++ b/docs/grafonnet/panel/geomap.md
@@ -160,6 +160,10 @@ grafonnet.panel.geomap
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1291,3 +1295,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/heatmap.md
+++ b/docs/grafonnet/panel/heatmap.md
@@ -208,6 +208,10 @@ grafonnet.panel.heatmap
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1672,3 +1676,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/histogram.md
+++ b/docs/grafonnet/panel/histogram.md
@@ -140,6 +140,10 @@ grafonnet.panel.histogram
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1128,3 +1132,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/logs.md
+++ b/docs/grafonnet/panel/logs.md
@@ -103,6 +103,10 @@ grafonnet.panel.logs
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -807,3 +811,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/news.md
+++ b/docs/grafonnet/panel/news.md
@@ -97,6 +97,10 @@ grafonnet.panel.news
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -749,3 +753,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/nodeGraph.md
+++ b/docs/grafonnet/panel/nodeGraph.md
@@ -110,6 +110,10 @@ grafonnet.panel.nodeGraph
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -851,3 +855,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/pieChart.md
+++ b/docs/grafonnet/panel/pieChart.md
@@ -139,6 +139,10 @@ grafonnet.panel.pieChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1110,3 +1114,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/stat.md
+++ b/docs/grafonnet/panel/stat.md
@@ -113,6 +113,10 @@ grafonnet.panel.stat
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -893,3 +897,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/stateTimeline.md
+++ b/docs/grafonnet/panel/stateTimeline.md
@@ -128,6 +128,10 @@ grafonnet.panel.stateTimeline
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1021,3 +1025,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/statusHistory.md
+++ b/docs/grafonnet/panel/statusHistory.md
@@ -127,6 +127,10 @@ grafonnet.panel.statusHistory
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1010,3 +1014,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/table.md
+++ b/docs/grafonnet/panel/table.md
@@ -118,6 +118,10 @@ grafonnet.panel.table
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -925,3 +929,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/text.md
+++ b/docs/grafonnet/panel/text.md
@@ -103,6 +103,10 @@ grafonnet.panel.text
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -802,3 +806,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/timeSeries.md
+++ b/docs/grafonnet/panel/timeSeries.md
@@ -167,6 +167,10 @@ grafonnet.panel.timeSeries
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1376,3 +1380,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/docs/grafonnet/panel/xyChart.md
+++ b/docs/grafonnet/panel/xyChart.md
@@ -183,6 +183,10 @@ grafonnet.panel.xyChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1493,3 +1497,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups.md
@@ -98,6 +98,10 @@ grafonnet.panel.alertGroups
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -758,3 +762,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList.md
@@ -106,6 +106,10 @@ grafonnet.panel.annotationsList
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -830,3 +834,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart.md
@@ -158,6 +158,10 @@ grafonnet.panel.barChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1290,3 +1294,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge.md
@@ -114,6 +114,10 @@ grafonnet.panel.barGauge
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -899,3 +903,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick.md
@@ -94,6 +94,10 @@ grafonnet.panel.candlestick
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -727,3 +731,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas.md
@@ -94,6 +94,10 @@ grafonnet.panel.canvas
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -727,3 +731,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList.md
@@ -105,6 +105,10 @@ grafonnet.panel.dashboardList
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -823,3 +827,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug.md
@@ -102,6 +102,10 @@ grafonnet.panel.debug
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -791,3 +795,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge.md
@@ -111,6 +111,10 @@ grafonnet.panel.gauge
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -867,3 +871,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap.md
@@ -160,6 +160,10 @@ grafonnet.panel.geomap
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1291,3 +1295,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap.md
@@ -208,6 +208,10 @@ grafonnet.panel.heatmap
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1672,3 +1676,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram.md
@@ -140,6 +140,10 @@ grafonnet.panel.histogram
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1128,3 +1132,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs.md
@@ -103,6 +103,10 @@ grafonnet.panel.logs
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -807,3 +811,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news.md
@@ -97,6 +97,10 @@ grafonnet.panel.news
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -749,3 +753,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph.md
@@ -110,6 +110,10 @@ grafonnet.panel.nodeGraph
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -851,3 +855,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart.md
@@ -139,6 +139,10 @@ grafonnet.panel.pieChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1110,3 +1114,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat.md
@@ -113,6 +113,10 @@ grafonnet.panel.stat
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -893,3 +897,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline.md
@@ -128,6 +128,10 @@ grafonnet.panel.stateTimeline
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1021,3 +1025,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory.md
@@ -127,6 +127,10 @@ grafonnet.panel.statusHistory
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1010,3 +1014,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table.md
@@ -118,6 +118,10 @@ grafonnet.panel.table
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -925,3 +929,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text.md
@@ -103,6 +103,10 @@ grafonnet.panel.text
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -802,3 +806,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries.md
@@ -167,6 +167,10 @@ grafonnet.panel.timeSeries
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1376,3 +1380,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart.md
@@ -183,6 +183,10 @@ grafonnet.panel.xyChart
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
+  * [`obj color`](#obj-standardoptionscolor)
+    * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
+    * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
+    * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
 
 ## Fields
 
@@ -1493,3 +1497,32 @@ withUnit(value)
 ```
 
 Numeric Options
+
+#### obj standardOptions.color
+
+
+##### fn standardOptions.color.withFixedColor
+
+```ts
+withFixedColor(value)
+```
+
+Stores the fixed color value if mode is fixed
+
+##### fn standardOptions.color.withMode
+
+```ts
+withMode(value)
+```
+
+The main color scheme mode
+
+##### fn standardOptions.color.withSeriesBy
+
+```ts
+withSeriesBy(value)
+```
+
+TODO docs
+
+Accepted values for `value` are "min", "max", "last"

--- a/grafonnet-base/helpers.libsonnet
+++ b/grafonnet-base/helpers.libsonnet
@@ -12,10 +12,7 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
   // Gets the content from source on a specified JSONPath
   getContent(source, path):
-    local content = xtd.jsonpath.getJSONPath(source, path);
-    if content == null
-    then self.last(xtd.string.splitEscape(path, '.'))
-    else content,
+    xtd.jsonpath.getJSONPath(source, path),
 
   // Sets the content on a specified ~JSONPath
   setContent(content, path):
@@ -50,7 +47,9 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
   // Transform moves the content from JSONPath `from` to JSONPath `to` in `source`
   transform(source, from, to):
     local content = root.getContent(source, from);
-    root.setContent(content, to)
+    if content == null
+    then {}
+    else root.setContent(content, to)
   ,
 
   // This functions transforms the canonical groupings representation to an array that can

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -35,9 +35,7 @@ local groupings = {
     'fieldConfig.defaults.withMax',
     'fieldConfig.defaults.withDecimals',
     'fieldConfig.defaults.withDisplayName',
-    'fieldConfig.defaults.color',  // to veneer // many options in UI dropdown
-    //'fieldConfig.defaults.withColor',  // to veneer // many options in UI dropdown
-    //'fieldConfig.defaults.withColorMixin',  // to veneer // many options in UI dropdown
+    'fieldConfig.defaults.color',
     'fieldConfig.defaults.withNoValue',
 
     // separate UI sections, to veneer


### PR DESCRIPTION
Objects are not created with docstrings but when mapping them, we also attempt to map
their docstrings. However `getContent` returns `null` and were returning the wrong
content.

This PR deals with `null` content by simply not mapping it. This makes the object visible
again in the docs.