### PR TITLE
refactor(veneer): sort out common panel options

### DIFF
--- a/docs/grafonnet/panel/alertGroups.md
+++ b/docs/grafonnet/panel/alertGroups.md
@@ -13,52 +13,9 @@ grafonnet.panel.alertGroups
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -94,14 +51,24 @@ grafonnet.panel.alertGroups
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -112,152 +79,6 @@ new(title)
 ```
 
 Creates a new alertGroups panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -277,200 +98,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -731,6 +358,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -754,6 +413,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -791,3 +466,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/annotationsList.md
+++ b/docs/grafonnet/panel/annotationsList.md
@@ -13,52 +13,9 @@ grafonnet.panel.annotationsList
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -102,14 +59,24 @@ grafonnet.panel.annotationsList
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -120,152 +87,6 @@ new(title)
 ```
 
 Creates a new annotationsList panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -285,200 +106,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -803,6 +430,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -826,6 +485,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -863,3 +538,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/barChart.md
+++ b/docs/grafonnet/panel/barChart.md
@@ -13,48 +13,11 @@ grafonnet.panel.barChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -83,10 +46,6 @@ grafonnet.panel.barChart
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
       * [`obj thresholdsStyle`](#obj-fieldconfigdefaultscustomthresholdsstyle)
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -154,14 +113,24 @@ grafonnet.panel.barChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -172,152 +141,6 @@ new(title)
 ```
 
 Creates a new barChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -341,167 +164,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -716,35 +380,6 @@ withMode(value)
 TODO docs
 
 Accepted values for `value` are "off", "line", "dashed", "area", "line+area", "dashed+area", "series"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1263,6 +898,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1286,6 +953,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1323,3 +1006,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/barGauge.md
+++ b/docs/grafonnet/panel/barGauge.md
@@ -13,52 +13,9 @@ grafonnet.panel.barGauge
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -110,14 +67,24 @@ grafonnet.panel.barGauge
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -128,152 +95,6 @@ new(title)
 ```
 
 Creates a new barGauge panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -293,200 +114,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -872,6 +499,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -895,6 +554,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -932,3 +607,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/candlestick.md
+++ b/docs/grafonnet/panel/candlestick.md
@@ -13,52 +13,9 @@ grafonnet.panel.candlestick
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -90,14 +47,24 @@ grafonnet.panel.candlestick
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -108,152 +75,6 @@ new(title)
 ```
 
 Creates a new candlestick panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -273,200 +94,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -700,6 +327,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -723,6 +382,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -760,3 +435,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/canvas.md
+++ b/docs/grafonnet/panel/canvas.md
@@ -13,52 +13,9 @@ grafonnet.panel.canvas
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -90,14 +47,24 @@ grafonnet.panel.canvas
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -108,152 +75,6 @@ new(title)
 ```
 
 Creates a new canvas panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -273,200 +94,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -700,6 +327,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -723,6 +382,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -760,3 +435,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/dashboardList.md
+++ b/docs/grafonnet/panel/dashboardList.md
@@ -13,52 +13,9 @@ grafonnet.panel.dashboardList
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -101,14 +58,24 @@ grafonnet.panel.dashboardList
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -119,152 +86,6 @@ new(title)
 ```
 
 Creates a new dashboardList panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -284,200 +105,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -796,6 +423,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -819,6 +478,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -856,3 +531,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/debug.md
+++ b/docs/grafonnet/panel/debug.md
@@ -13,52 +13,9 @@ grafonnet.panel.debug
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -98,14 +55,24 @@ grafonnet.panel.debug
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -116,152 +83,6 @@ new(title)
 ```
 
 Creates a new debug panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -281,200 +102,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -764,6 +391,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -787,6 +446,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -824,3 +499,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/gauge.md
+++ b/docs/grafonnet/panel/gauge.md
@@ -13,52 +13,9 @@ grafonnet.panel.gauge
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -107,14 +64,24 @@ grafonnet.panel.gauge
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -125,152 +92,6 @@ new(title)
 ```
 
 Creates a new gauge panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -290,200 +111,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -840,6 +467,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -863,6 +522,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -900,3 +575,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/geomap.md
+++ b/docs/grafonnet/panel/geomap.md
@@ -13,52 +13,9 @@ grafonnet.panel.geomap
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -156,14 +113,24 @@ grafonnet.panel.geomap
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -174,152 +141,6 @@ new(title)
 ```
 
 Creates a new geomap panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -339,200 +160,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1264,6 +891,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1287,6 +946,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1324,3 +999,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/heatmap.md
+++ b/docs/grafonnet/panel/heatmap.md
@@ -13,48 +13,11 @@ grafonnet.panel.heatmap
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
@@ -68,10 +31,6 @@ grafonnet.panel.heatmap
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -204,14 +163,24 @@ grafonnet.panel.heatmap
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -222,152 +191,6 @@ new(title)
 ```
 
 Creates a new heatmap panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -391,167 +214,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -643,35 +307,6 @@ withType(value)
 TODO docs
 
 Accepted values for `value` are "linear", "log", "ordinal", "symlog"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1645,6 +1280,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1668,6 +1335,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1705,3 +1388,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/histogram.md
+++ b/docs/grafonnet/panel/histogram.md
@@ -13,48 +13,11 @@ grafonnet.panel.histogram
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -79,10 +42,6 @@ grafonnet.panel.histogram
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -136,14 +95,24 @@ grafonnet.panel.histogram
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -154,152 +123,6 @@ new(title)
 ```
 
 Creates a new histogram panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -323,167 +146,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -669,35 +333,6 @@ withType(value)
 TODO docs
 
 Accepted values for `value` are "linear", "log", "ordinal", "symlog"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1101,6 +736,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1124,6 +791,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1161,3 +844,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/logs.md
+++ b/docs/grafonnet/panel/logs.md
@@ -13,52 +13,9 @@ grafonnet.panel.logs
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -99,14 +56,24 @@ grafonnet.panel.logs
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -117,152 +84,6 @@ new(title)
 ```
 
 Creates a new logs panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -282,200 +103,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -780,6 +407,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -803,6 +462,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -840,3 +515,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/news.md
+++ b/docs/grafonnet/panel/news.md
@@ -13,52 +13,9 @@ grafonnet.panel.news
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -93,14 +50,24 @@ grafonnet.panel.news
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -111,152 +78,6 @@ new(title)
 ```
 
 Creates a new news panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -276,200 +97,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -722,6 +349,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -745,6 +404,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -782,3 +457,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/nodeGraph.md
+++ b/docs/grafonnet/panel/nodeGraph.md
@@ -13,52 +13,9 @@ grafonnet.panel.nodeGraph
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -106,14 +63,24 @@ grafonnet.panel.nodeGraph
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -124,152 +91,6 @@ new(title)
 ```
 
 Creates a new nodeGraph panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -289,200 +110,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -824,6 +451,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -847,6 +506,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -884,3 +559,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/pieChart.md
+++ b/docs/grafonnet/panel/pieChart.md
@@ -13,48 +13,11 @@ grafonnet.panel.pieChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
@@ -62,10 +25,6 @@ grafonnet.panel.pieChart
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -135,14 +94,24 @@ grafonnet.panel.pieChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -153,152 +122,6 @@ new(title)
 ```
 
 Creates a new pieChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -322,167 +145,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -529,35 +193,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1083,6 +718,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1106,6 +773,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1143,3 +826,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/stat.md
+++ b/docs/grafonnet/panel/stat.md
@@ -13,52 +13,9 @@ grafonnet.panel.stat
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -109,14 +66,24 @@ grafonnet.panel.stat
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -127,152 +94,6 @@ new(title)
 ```
 
 Creates a new stat panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -292,200 +113,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -866,6 +493,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -889,6 +548,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -926,3 +601,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/stateTimeline.md
+++ b/docs/grafonnet/panel/stateTimeline.md
@@ -13,48 +13,11 @@ grafonnet.panel.stateTimeline
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withFillOpacity(value=70)`](#fn-fieldconfigdefaultscustomwithfillopacity)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
@@ -64,10 +27,6 @@ grafonnet.panel.stateTimeline
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -124,14 +83,24 @@ grafonnet.panel.stateTimeline
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -142,152 +111,6 @@ new(title)
 ```
 
 Creates a new stateTimeline panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -311,167 +134,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -534,35 +198,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -994,6 +629,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1017,6 +684,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1054,3 +737,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/statusHistory.md
+++ b/docs/grafonnet/panel/statusHistory.md
@@ -13,48 +13,11 @@ grafonnet.panel.statusHistory
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withFillOpacity(value=70)`](#fn-fieldconfigdefaultscustomwithfillopacity)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
@@ -64,10 +27,6 @@ grafonnet.panel.statusHistory
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -123,14 +82,24 @@ grafonnet.panel.statusHistory
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -141,152 +110,6 @@ new(title)
 ```
 
 Creates a new statusHistory panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -310,167 +133,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -533,35 +197,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -983,6 +618,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1006,6 +673,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1043,3 +726,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/table.md
+++ b/docs/grafonnet/panel/table.md
@@ -13,52 +13,9 @@ grafonnet.panel.table
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -114,14 +71,24 @@ grafonnet.panel.table
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -132,152 +99,6 @@ new(title)
 ```
 
 Creates a new table panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -297,200 +118,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -898,6 +525,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -921,6 +580,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -958,3 +633,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/text.md
+++ b/docs/grafonnet/panel/text.md
@@ -13,52 +13,9 @@ grafonnet.panel.text
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -99,14 +56,24 @@ grafonnet.panel.text
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -117,152 +84,6 @@ new(title)
 ```
 
 Creates a new text panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -282,200 +103,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -775,6 +402,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -798,6 +457,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -835,3 +510,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/timeSeries.md
+++ b/docs/grafonnet/panel/timeSeries.md
@@ -13,48 +13,11 @@ grafonnet.panel.timeSeries
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -109,10 +72,6 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomstackingwithmode)
       * [`obj thresholdsStyle`](#obj-fieldconfigdefaultscustomthresholdsstyle)
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -163,14 +122,24 @@ grafonnet.panel.timeSeries
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -181,152 +150,6 @@ new(title)
 ```
 
 Creates a new timeSeries panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -350,167 +173,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -942,35 +606,6 @@ TODO docs
 
 Accepted values for `value` are "off", "line", "dashed", "area", "line+area", "dashed+area", "series"
 
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
 ### obj gridPos
 
 
@@ -1349,6 +984,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1372,6 +1039,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1409,3 +1092,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/docs/grafonnet/panel/xyChart.md
+++ b/docs/grafonnet/panel/xyChart.md
@@ -13,52 +13,9 @@ grafonnet.panel.xyChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -179,14 +136,24 @@ grafonnet.panel.xyChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -197,152 +164,6 @@ new(title)
 ```
 
 Creates a new xyChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -362,200 +183,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1466,6 +1093,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1489,6 +1148,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1526,3 +1201,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups.md
@@ -13,52 +13,9 @@ grafonnet.panel.alertGroups
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -94,14 +51,24 @@ grafonnet.panel.alertGroups
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -112,152 +79,6 @@ new(title)
 ```
 
 Creates a new alertGroups panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -277,200 +98,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -731,6 +358,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -754,6 +413,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -791,3 +466,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList.md
@@ -13,52 +13,9 @@ grafonnet.panel.annotationsList
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -102,14 +59,24 @@ grafonnet.panel.annotationsList
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -120,152 +87,6 @@ new(title)
 ```
 
 Creates a new annotationsList panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -285,200 +106,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -803,6 +430,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -826,6 +485,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -863,3 +538,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart.md
@@ -13,48 +13,11 @@ grafonnet.panel.barChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -83,10 +46,6 @@ grafonnet.panel.barChart
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
       * [`obj thresholdsStyle`](#obj-fieldconfigdefaultscustomthresholdsstyle)
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -154,14 +113,24 @@ grafonnet.panel.barChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -172,152 +141,6 @@ new(title)
 ```
 
 Creates a new barChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -341,167 +164,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -716,35 +380,6 @@ withMode(value)
 TODO docs
 
 Accepted values for `value` are "off", "line", "dashed", "area", "line+area", "dashed+area", "series"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1263,6 +898,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1286,6 +953,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1323,3 +1006,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge.md
@@ -13,52 +13,9 @@ grafonnet.panel.barGauge
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -110,14 +67,24 @@ grafonnet.panel.barGauge
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -128,152 +95,6 @@ new(title)
 ```
 
 Creates a new barGauge panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -293,200 +114,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -872,6 +499,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -895,6 +554,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -932,3 +607,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick.md
@@ -13,52 +13,9 @@ grafonnet.panel.candlestick
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -90,14 +47,24 @@ grafonnet.panel.candlestick
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -108,152 +75,6 @@ new(title)
 ```
 
 Creates a new candlestick panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -273,200 +94,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -700,6 +327,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -723,6 +382,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -760,3 +435,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas.md
@@ -13,52 +13,9 @@ grafonnet.panel.canvas
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -90,14 +47,24 @@ grafonnet.panel.canvas
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -108,152 +75,6 @@ new(title)
 ```
 
 Creates a new canvas panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -273,200 +94,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -700,6 +327,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -723,6 +382,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -760,3 +435,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList.md
@@ -13,52 +13,9 @@ grafonnet.panel.dashboardList
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -101,14 +58,24 @@ grafonnet.panel.dashboardList
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -119,152 +86,6 @@ new(title)
 ```
 
 Creates a new dashboardList panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -284,200 +105,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -796,6 +423,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -819,6 +478,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -856,3 +531,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug.md
@@ -13,52 +13,9 @@ grafonnet.panel.debug
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -98,14 +55,24 @@ grafonnet.panel.debug
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -116,152 +83,6 @@ new(title)
 ```
 
 Creates a new debug panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -281,200 +102,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -764,6 +391,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -787,6 +446,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -824,3 +499,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge.md
@@ -13,52 +13,9 @@ grafonnet.panel.gauge
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -107,14 +64,24 @@ grafonnet.panel.gauge
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -125,152 +92,6 @@ new(title)
 ```
 
 Creates a new gauge panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -290,200 +111,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -840,6 +467,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -863,6 +522,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -900,3 +575,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap.md
@@ -13,52 +13,9 @@ grafonnet.panel.geomap
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -156,14 +113,24 @@ grafonnet.panel.geomap
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -174,152 +141,6 @@ new(title)
 ```
 
 Creates a new geomap panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -339,200 +160,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1264,6 +891,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1287,6 +946,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1324,3 +999,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap.md
@@ -13,48 +13,11 @@ grafonnet.panel.heatmap
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
@@ -68,10 +31,6 @@ grafonnet.panel.heatmap
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -204,14 +163,24 @@ grafonnet.panel.heatmap
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -222,152 +191,6 @@ new(title)
 ```
 
 Creates a new heatmap panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -391,167 +214,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -643,35 +307,6 @@ withType(value)
 TODO docs
 
 Accepted values for `value` are "linear", "log", "ordinal", "symlog"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1645,6 +1280,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1668,6 +1335,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1705,3 +1388,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram.md
@@ -13,48 +13,11 @@ grafonnet.panel.histogram
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -79,10 +42,6 @@ grafonnet.panel.histogram
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -136,14 +95,24 @@ grafonnet.panel.histogram
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -154,152 +123,6 @@ new(title)
 ```
 
 Creates a new histogram panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -323,167 +146,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -669,35 +333,6 @@ withType(value)
 TODO docs
 
 Accepted values for `value` are "linear", "log", "ordinal", "symlog"
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1101,6 +736,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1124,6 +791,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1161,3 +844,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs.md
@@ -13,52 +13,9 @@ grafonnet.panel.logs
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -99,14 +56,24 @@ grafonnet.panel.logs
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -117,152 +84,6 @@ new(title)
 ```
 
 Creates a new logs panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -282,200 +103,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -780,6 +407,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -803,6 +462,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -840,3 +515,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news.md
@@ -13,52 +13,9 @@ grafonnet.panel.news
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -93,14 +50,24 @@ grafonnet.panel.news
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -111,152 +78,6 @@ new(title)
 ```
 
 Creates a new news panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -276,200 +97,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -722,6 +349,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -745,6 +404,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -782,3 +457,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph.md
@@ -13,52 +13,9 @@ grafonnet.panel.nodeGraph
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -106,14 +63,24 @@ grafonnet.panel.nodeGraph
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -124,152 +91,6 @@ new(title)
 ```
 
 Creates a new nodeGraph panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -289,200 +110,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -824,6 +451,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -847,6 +506,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -884,3 +559,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart.md
@@ -13,48 +13,11 @@ grafonnet.panel.pieChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
@@ -62,10 +25,6 @@ grafonnet.panel.pieChart
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -135,14 +94,24 @@ grafonnet.panel.pieChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -153,152 +122,6 @@ new(title)
 ```
 
 Creates a new pieChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -322,167 +145,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -529,35 +193,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1083,6 +718,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1106,6 +773,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1143,3 +826,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat.md
@@ -13,52 +13,9 @@ grafonnet.panel.stat
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -109,14 +66,24 @@ grafonnet.panel.stat
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -127,152 +94,6 @@ new(title)
 ```
 
 Creates a new stat panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -292,200 +113,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -866,6 +493,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -889,6 +548,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -926,3 +601,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline.md
@@ -13,48 +13,11 @@ grafonnet.panel.stateTimeline
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withFillOpacity(value=70)`](#fn-fieldconfigdefaultscustomwithfillopacity)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
@@ -64,10 +27,6 @@ grafonnet.panel.stateTimeline
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -124,14 +83,24 @@ grafonnet.panel.stateTimeline
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -142,152 +111,6 @@ new(title)
 ```
 
 Creates a new stateTimeline panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -311,167 +134,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -534,35 +198,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -994,6 +629,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1017,6 +684,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1054,3 +737,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory.md
@@ -13,48 +13,11 @@ grafonnet.panel.statusHistory
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withFillOpacity(value=70)`](#fn-fieldconfigdefaultscustomwithfillopacity)
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
@@ -64,10 +27,6 @@ grafonnet.panel.statusHistory
         * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
         * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
         * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -123,14 +82,24 @@ grafonnet.panel.statusHistory
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -141,152 +110,6 @@ new(title)
 ```
 
 Creates a new statusHistory panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -310,167 +133,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -533,35 +197,6 @@ withViz(value)
 ```
 
 
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -983,6 +618,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1006,6 +673,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1043,3 +726,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table.md
@@ -13,52 +13,9 @@ grafonnet.panel.table
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -114,14 +71,24 @@ grafonnet.panel.table
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -132,152 +99,6 @@ new(title)
 ```
 
 Creates a new table panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -297,200 +118,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -898,6 +525,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -921,6 +580,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -958,3 +633,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text.md
@@ -13,52 +13,9 @@ grafonnet.panel.text
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -99,14 +56,24 @@ grafonnet.panel.text
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -117,152 +84,6 @@ new(title)
 ```
 
 Creates a new text panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -282,200 +103,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -775,6 +402,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -798,6 +457,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -835,3 +510,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries.md
@@ -13,48 +13,11 @@ grafonnet.panel.timeSeries
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
   * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
       * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
@@ -109,10 +72,6 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomstackingwithmode)
       * [`obj thresholdsStyle`](#obj-fieldconfigdefaultscustomthresholdsstyle)
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -163,14 +122,24 @@ grafonnet.panel.timeSeries
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -181,152 +150,6 @@ new(title)
 ```
 
 Creates a new timeSeries panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -350,167 +173,8 @@ withUid(value)
 ### obj fieldConfig
 
 
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
 #### obj fieldConfig.defaults
 
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
 
 ##### obj fieldConfig.defaults.custom
 
@@ -942,35 +606,6 @@ TODO docs
 
 Accepted values for `value` are "off", "line", "dashed", "area", "line+area", "dashed+area", "series"
 
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
 ### obj gridPos
 
 
@@ -1349,6 +984,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1372,6 +1039,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1409,3 +1092,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart.md
@@ -13,52 +13,9 @@ grafonnet.panel.xyChart
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withFieldConfig(value)`](#fn-withfieldconfig)
-* [`fn withFieldConfigMixin(value)`](#fn-withfieldconfigmixin)
-* [`fn withGridPos(value)`](#fn-withgridpos)
-* [`fn withGridPosMixin(value)`](#fn-withgridposmixin)
-* [`fn withId(value)`](#fn-withid)
-* [`fn withLibraryPanel(value)`](#fn-withlibrarypanel)
-* [`fn withLibraryPanelMixin(value)`](#fn-withlibrarypanelmixin)
-* [`fn withOptions(value)`](#fn-withoptions)
-* [`fn withOptionsMixin(value)`](#fn-withoptionsmixin)
-* [`fn withPluginVersion(value)`](#fn-withpluginversion)
-* [`fn withRepeatPanelId(value)`](#fn-withrepeatpanelid)
-* [`fn withTags(value)`](#fn-withtags)
-* [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withThresholds(value)`](#fn-withthresholds)
-* [`fn withThresholdsMixin(value)`](#fn-withthresholdsmixin)
-* [`fn withTimeRegions(value)`](#fn-withtimeregions)
-* [`fn withTimeRegionsMixin(value)`](#fn-withtimeregionsmixin)
-* [`fn withType()`](#fn-withtype)
 * [`obj datasource`](#obj-datasource)
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
-* [`obj fieldConfig`](#obj-fieldconfig)
-  * [`fn withDefaults(value)`](#fn-fieldconfigwithdefaults)
-  * [`fn withDefaultsMixin(value)`](#fn-fieldconfigwithdefaultsmixin)
-  * [`fn withOverrides(value)`](#fn-fieldconfigwithoverrides)
-  * [`fn withOverridesMixin(value)`](#fn-fieldconfigwithoverridesmixin)
-  * [`obj defaults`](#obj-fieldconfigdefaults)
-    * [`fn withColor(value)`](#fn-fieldconfigdefaultswithcolor)
-    * [`fn withColorMixin(value)`](#fn-fieldconfigdefaultswithcolormixin)
-    * [`fn withCustom(value)`](#fn-fieldconfigdefaultswithcustom)
-    * [`fn withCustomMixin(value)`](#fn-fieldconfigdefaultswithcustommixin)
-    * [`fn withDescription(value)`](#fn-fieldconfigdefaultswithdescription)
-    * [`fn withDisplayNameFromDS(value)`](#fn-fieldconfigdefaultswithdisplaynamefromds)
-    * [`fn withFilterable(value)`](#fn-fieldconfigdefaultswithfilterable)
-    * [`fn withLinks(value)`](#fn-fieldconfigdefaultswithlinks)
-    * [`fn withLinksMixin(value)`](#fn-fieldconfigdefaultswithlinksmixin)
-    * [`fn withMappings(value)`](#fn-fieldconfigdefaultswithmappings)
-    * [`fn withMappingsMixin(value)`](#fn-fieldconfigdefaultswithmappingsmixin)
-    * [`fn withPath(value)`](#fn-fieldconfigdefaultswithpath)
-    * [`fn withThresholds(value)`](#fn-fieldconfigdefaultswiththresholds)
-    * [`fn withThresholdsMixin(value)`](#fn-fieldconfigdefaultswiththresholdsmixin)
-    * [`fn withWriteable(value)`](#fn-fieldconfigdefaultswithwriteable)
-    * [`obj thresholds`](#obj-fieldconfigdefaultsthresholds)
-      * [`fn withMode(value)`](#fn-fieldconfigdefaultsthresholdswithmode)
-      * [`fn withSteps(value)`](#fn-fieldconfigdefaultsthresholdswithsteps)
-      * [`fn withStepsMixin(value)`](#fn-fieldconfigdefaultsthresholdswithstepsmixin)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
   * [`fn withStatic(value)`](#fn-gridposwithstatic)
@@ -179,14 +136,24 @@ grafonnet.panel.xyChart
 * [`obj standardOptions`](#obj-standardoptions)
   * [`fn withDecimals(value)`](#fn-standardoptionswithdecimals)
   * [`fn withDisplayName(value)`](#fn-standardoptionswithdisplayname)
+  * [`fn withLinks(value)`](#fn-standardoptionswithlinks)
+  * [`fn withLinksMixin(value)`](#fn-standardoptionswithlinksmixin)
+  * [`fn withMappings(value)`](#fn-standardoptionswithmappings)
+  * [`fn withMappingsMixin(value)`](#fn-standardoptionswithmappingsmixin)
   * [`fn withMax(value)`](#fn-standardoptionswithmax)
   * [`fn withMin(value)`](#fn-standardoptionswithmin)
   * [`fn withNoValue(value)`](#fn-standardoptionswithnovalue)
+  * [`fn withOverrides(value)`](#fn-standardoptionswithoverrides)
+  * [`fn withOverridesMixin(value)`](#fn-standardoptionswithoverridesmixin)
   * [`fn withUnit(value)`](#fn-standardoptionswithunit)
   * [`obj color`](#obj-standardoptionscolor)
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
+  * [`obj tresholds`](#obj-standardoptionstresholds)
+    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
 
 ## Fields
 
@@ -197,152 +164,6 @@ new(title)
 ```
 
 Creates a new xyChart panel with a title.
-
-### fn withFieldConfig
-
-```ts
-withFieldConfig(value)
-```
-
-
-
-### fn withFieldConfigMixin
-
-```ts
-withFieldConfigMixin(value)
-```
-
-
-
-### fn withGridPos
-
-```ts
-withGridPos(value)
-```
-
-
-
-### fn withGridPosMixin
-
-```ts
-withGridPosMixin(value)
-```
-
-
-
-### fn withId
-
-```ts
-withId(value)
-```
-
-TODO docs
-
-### fn withLibraryPanel
-
-```ts
-withLibraryPanel(value)
-```
-
-
-
-### fn withLibraryPanelMixin
-
-```ts
-withLibraryPanelMixin(value)
-```
-
-
-
-### fn withOptions
-
-```ts
-withOptions(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withOptionsMixin
-
-```ts
-withOptionsMixin(value)
-```
-
-options is specified by the PanelOptions field in panel
-plugin schemas.
-
-### fn withPluginVersion
-
-```ts
-withPluginVersion(value)
-```
-
-FIXME this almost certainly has to be changed in favor of scuemata versions
-
-### fn withRepeatPanelId
-
-```ts
-withRepeatPanelId(value)
-```
-
-Id of the repeating panel.
-
-### fn withTags
-
-```ts
-withTags(value)
-```
-
-TODO docs
-
-### fn withTagsMixin
-
-```ts
-withTagsMixin(value)
-```
-
-TODO docs
-
-### fn withThresholds
-
-```ts
-withThresholds(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-TODO docs - seems to be an old field from old dashboard alerts?
-
-### fn withTimeRegions
-
-```ts
-withTimeRegions(value)
-```
-
-TODO docs
-
-### fn withTimeRegionsMixin
-
-```ts
-withTimeRegionsMixin(value)
-```
-
-TODO docs
-
-### fn withType
-
-```ts
-withType()
-```
-
-
 
 ### obj datasource
 
@@ -362,200 +183,6 @@ withUid(value)
 ```
 
 
-
-### obj fieldConfig
-
-
-#### fn fieldConfig.withDefaults
-
-```ts
-withDefaults(value)
-```
-
-
-
-#### fn fieldConfig.withDefaultsMixin
-
-```ts
-withDefaultsMixin(value)
-```
-
-
-
-#### fn fieldConfig.withOverrides
-
-```ts
-withOverrides(value)
-```
-
-
-
-#### fn fieldConfig.withOverridesMixin
-
-```ts
-withOverridesMixin(value)
-```
-
-
-
-#### obj fieldConfig.defaults
-
-
-##### fn fieldConfig.defaults.withColor
-
-```ts
-withColor(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withColorMixin
-
-```ts
-withColorMixin(value)
-```
-
-TODO docs
-
-##### fn fieldConfig.defaults.withCustom
-
-```ts
-withCustom(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withCustomMixin
-
-```ts
-withCustomMixin(value)
-```
-
-custom is specified by the PanelFieldConfig field
-in panel plugin schemas.
-
-##### fn fieldConfig.defaults.withDescription
-
-```ts
-withDescription(value)
-```
-
-Human readable field metadata
-
-##### fn fieldConfig.defaults.withDisplayNameFromDS
-
-```ts
-withDisplayNameFromDS(value)
-```
-
-This can be used by data sources that return and explicit naming structure for values and labels
-When this property is configured, this value is used rather than the default naming strategy.
-
-##### fn fieldConfig.defaults.withFilterable
-
-```ts
-withFilterable(value)
-```
-
-True if data source field supports ad-hoc filters
-
-##### fn fieldConfig.defaults.withLinks
-
-```ts
-withLinks(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withLinksMixin
-
-```ts
-withLinksMixin(value)
-```
-
-The behavior when clicking on a result
-
-##### fn fieldConfig.defaults.withMappings
-
-```ts
-withMappings(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withMappingsMixin
-
-```ts
-withMappingsMixin(value)
-```
-
-Convert input values into a display string
-
-##### fn fieldConfig.defaults.withPath
-
-```ts
-withPath(value)
-```
-
-An explicit path to the field in the datasource.  When the frame meta includes a path,
-This will default to `${frame.meta.path}/${field.name}
-
-When defined, this value can be used as an identifier within the datasource scope, and
-may be used to update the results
-
-##### fn fieldConfig.defaults.withThresholds
-
-```ts
-withThresholds(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withThresholdsMixin
-
-```ts
-withThresholdsMixin(value)
-```
-
-
-
-##### fn fieldConfig.defaults.withWriteable
-
-```ts
-withWriteable(value)
-```
-
-True if data source can write a value to the path.  Auth/authz are supported separately
-
-##### obj fieldConfig.defaults.thresholds
-
-
-###### fn fieldConfig.defaults.thresholds.withMode
-
-```ts
-withMode(value)
-```
-
-
-
-Accepted values for `value` are "absolute", "percentage"
-
-###### fn fieldConfig.defaults.thresholds.withSteps
-
-```ts
-withSteps(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
-
-###### fn fieldConfig.defaults.thresholds.withStepsMixin
-
-```ts
-withStepsMixin(value)
-```
-
-Must be sorted by 'value', first value is always -Infinity
 
 ### obj gridPos
 
@@ -1466,6 +1093,38 @@ withDisplayName(value)
 
 The display value for this field.  This supports template variables blank is auto
 
+#### fn standardOptions.withLinks
+
+```ts
+withLinks(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withLinksMixin
+
+```ts
+withLinksMixin(value)
+```
+
+The behavior when clicking on a result
+
+#### fn standardOptions.withMappings
+
+```ts
+withMappings(value)
+```
+
+Convert input values into a display string
+
+#### fn standardOptions.withMappingsMixin
+
+```ts
+withMappingsMixin(value)
+```
+
+Convert input values into a display string
+
 #### fn standardOptions.withMax
 
 ```ts
@@ -1489,6 +1148,22 @@ withNoValue(value)
 ```
 
 Alternative to empty string
+
+#### fn standardOptions.withOverrides
+
+```ts
+withOverrides(value)
+```
+
+
+
+#### fn standardOptions.withOverridesMixin
+
+```ts
+withOverridesMixin(value)
+```
+
+
 
 #### fn standardOptions.withUnit
 
@@ -1526,3 +1201,32 @@ withSeriesBy(value)
 TODO docs
 
 Accepted values for `value` are "min", "max", "last"
+
+#### obj standardOptions.tresholds
+
+
+##### fn standardOptions.tresholds.withMode
+
+```ts
+withMode(value)
+```
+
+
+
+Accepted values for `value` are "absolute", "percentage"
+
+##### fn standardOptions.tresholds.withSteps
+
+```ts
+withSteps(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity
+
+##### fn standardOptions.tresholds.withStepsMixin
+
+```ts
+withStepsMixin(value)
+```
+
+Must be sorted by 'value', first value is always -Infinity

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -10,8 +10,6 @@ local groupings = {
     'withLinksMixin',
     'withRepeat',  // to veneer // missing maxPerRow
     'withRepeatDirection',
-    //'withRepeatPanelId', // not in UI
-    //'gridPos',  // user gridPos section // not an actual field in UI
   ],
 
   queryOptions: [
@@ -37,12 +35,21 @@ local groupings = {
     'fieldConfig.defaults.withDisplayName',
     'fieldConfig.defaults.color',
     'fieldConfig.defaults.withNoValue',
+    'fieldConfig.defaults.withLinks',  // known as 'Data links' in UI, uses links subpackage
+    'fieldConfig.defaults.withLinksMixin',
+    'fieldConfig.defaults.withMappings',  // known as 'Value mappings' in UI, uses valueMapping subpackage
+    'fieldConfig.defaults.withMappingsMixin',
 
-    // separate UI sections, to veneer
-    //'dataLinks',  // seems to depend on root based sub package
-    //'valueMappings',  // mappings sub package looks complex but consistent
-    //'thresholds',  // I've always found the threshold UI unintuitive // both found in root and fieldConfig.defaults ???
-    //'fieldOverrides',  // matcher = obj, properties = array, unclear in current grafonnet
+    // fieldOverrides needs to recieve more attention in Grafonnet, the JSON is unintuitive
+    // matcher = obj, properties = array, unclear in current grafonnet
+    'fieldConfig.withOverrides',  // known as 'Overrides' in UI, uses fieldOverrides subpackage
+    'fieldConfig.withOverridesMixin',
+  ],
+
+  'standardOptions.tresholds': [
+    'fieldConfig.defaults.thresholds.withMode',
+    'fieldConfig.defaults.thresholds.withSteps',
+    'fieldConfig.defaults.thresholds.withStepsMixin',
   ],
 };
 
@@ -74,10 +81,57 @@ local subPackages = [
   },
 ];
 
+local toRemove = [
+  // Access through more specific attributes
+  '#withFieldConfig',
+  '#withFieldConfigMixin',
+  '#withGridPos',
+  '#withGridPosMixin',
+  '#withOptions',
+  '#withOptionsMixin',
+  'fieldConfig.#withDefaults',
+  'fieldConfig.#withDefaultsMixin',
+  'fieldConfig.defaults.#withColor',
+  'fieldConfig.defaults.#withColorMixin',
+  'fieldConfig.defaults.#withCustom',
+  'fieldConfig.defaults.#withCustomMixin',
+  'fieldConfig.defaults.#withThresholds',
+  'fieldConfig.defaults.#withThresholdsMixin',
+
+  // Internal
+  '#withId',
+  '#withPluginVersion',
+  '#withRepeatPanelId',
+  '#withType',
+
+  // Not in UI
+  '#withLibraryPanel',
+  '#withLibraryPanelMixin',
+  '#withTags',  // seems to be related to search
+  '#withTagsMixin',
+  'fieldConfig.defaults.#withDescription',
+  'fieldConfig.defaults.#withDisplayNameFromDS',
+  'fieldConfig.defaults.#withFilterable',  // only found in overrides
+  'fieldConfig.defaults.#withPath',  // also related to overrides
+  'fieldConfig.defaults.#withWriteable',
+
+  // Old fields, not used anymore
+  '#withThresholds',
+  '#withThresholdsMixin',
+  '#withTimeRegions',
+  '#withTimeRegionsMixin',
+];
+
 
 function(name, panel)
   helpers.regroup(panel, groupings)
   + helpers.repackage(panel, subPackages)
+  + std.foldl(
+    function(acc, path)
+      acc + helpers.removeContent(panel, path),
+    toRemove,
+    {}
+  )
   + {
     '#new':: d.func.new(
       'Creates a new %s panel with a title.' % name,
@@ -91,7 +145,4 @@ function(name, panel)
       // interesting from a reusability standpoint.
       + self.datasource.withType('datasource')
       + self.datasource.withUid('-- Mixed --'),
-
-    //standardOptions+: { '#color': d.obj('color') },
-
   }


### PR DESCRIPTION
Building further upon #55, this sorts out all of the common panel options shared across
all panels. It also removes a lot of options from the documentation that don't seems to be
user configurable, these are up for discussion with the dashboard team.