### PR TITLE
feat(veneer): improve panel field override

### DIFF
--- a/docs/grafonnet/panel/alertGroups/fieldOverride.md
+++ b/docs/grafonnet/panel/alertGroups/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/annotationsList/fieldOverride.md
+++ b/docs/grafonnet/panel/annotationsList/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/barChart/fieldOverride.md
+++ b/docs/grafonnet/panel/barChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/barGauge/fieldOverride.md
+++ b/docs/grafonnet/panel/barGauge/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/candlestick/fieldOverride.md
+++ b/docs/grafonnet/panel/candlestick/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/canvas/fieldOverride.md
+++ b/docs/grafonnet/panel/canvas/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/dashboardList/fieldOverride.md
+++ b/docs/grafonnet/panel/dashboardList/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/debug/fieldOverride.md
+++ b/docs/grafonnet/panel/debug/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/gauge/fieldOverride.md
+++ b/docs/grafonnet/panel/gauge/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/geomap/fieldOverride.md
+++ b/docs/grafonnet/panel/geomap/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/heatmap/fieldOverride.md
+++ b/docs/grafonnet/panel/heatmap/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/histogram/fieldOverride.md
+++ b/docs/grafonnet/panel/histogram/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/logs/fieldOverride.md
+++ b/docs/grafonnet/panel/logs/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/news/fieldOverride.md
+++ b/docs/grafonnet/panel/news/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/nodeGraph/fieldOverride.md
+++ b/docs/grafonnet/panel/nodeGraph/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/pieChart/fieldOverride.md
+++ b/docs/grafonnet/panel/pieChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/stat/fieldOverride.md
+++ b/docs/grafonnet/panel/stat/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/stateTimeline/fieldOverride.md
+++ b/docs/grafonnet/panel/stateTimeline/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/statusHistory/fieldOverride.md
+++ b/docs/grafonnet/panel/statusHistory/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/table/fieldOverride.md
+++ b/docs/grafonnet/panel/table/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/text/fieldOverride.md
+++ b/docs/grafonnet/panel/text/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/timeSeries/fieldOverride.md
+++ b/docs/grafonnet/panel/timeSeries/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/docs/grafonnet/panel/xyChart/fieldOverride.md
+++ b/docs/grafonnet/panel/xyChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/fieldOverride.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/fieldOverride.md
@@ -1,88 +1,194 @@
 # fieldOverride
 
+Overrides allow you to customize visualization settings for specific fields or
+series. This is accomplished by adding an override rule that targets
+a particular set of fields and that can each define multiple options.
+
+```jsonnet
+fieldOverride.byType.new('number')
++ fieldOverride.byType.withPropertiesFromOptions(
+  panel.standardOptions.withDecimals(2)
+  + panel.standardOptions.withUnit('s')
+)
+```
 
 
 ## Index
 
-* [`fn withMatcher(value)`](#fn-withmatcher)
-* [`fn withMatcherMixin(value)`](#fn-withmatchermixin)
-* [`fn withProperties(value)`](#fn-withproperties)
-* [`fn withPropertiesMixin(value)`](#fn-withpropertiesmixin)
-* [`obj matcher`](#obj-matcher)
-  * [`fn withId(value="")`](#fn-matcherwithid)
-  * [`fn withOptions(value)`](#fn-matcherwithoptions)
-* [`obj properties`](#obj-properties)
-  * [`fn withId(value="")`](#fn-propertieswithid)
-  * [`fn withValue(value)`](#fn-propertieswithvalue)
+* [`obj byName`](#obj-byname)
+  * [`fn new(value)`](#fn-bynamenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bynamewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bynamewithproperty)
+* [`obj byQuery`](#obj-byquery)
+  * [`fn new(value)`](#fn-byquerynew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
+* [`obj byRegex`](#obj-byregex)
+  * [`fn new(value)`](#fn-byregexnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byType`](#obj-bytype)
+  * [`fn new(value)`](#fn-bytypenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-bytypewithproperty)
+* [`obj byValue`](#obj-byvalue)
+  * [`fn new(value)`](#fn-byvaluenew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byvaluewithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byvaluewithproperty)
 
 ## Fields
 
-### fn withMatcher
+### obj byName
+
+
+#### fn byName.new
 
 ```ts
-withMatcher(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### fn withMatcherMixin
+#### fn byName.withPropertiesFromOptions
 
 ```ts
-withMatcherMixin(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-### fn withProperties
+#### fn byName.withProperty
 
 ```ts
-withProperties(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### fn withPropertiesMixin
+### obj byQuery
+
+
+#### fn byQuery.new
 
 ```ts
-withPropertiesMixin(value)
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-### obj matcher
-
-
-#### fn matcher.withId
+#### fn byQuery.withPropertiesFromOptions
 
 ```ts
-withId(value="")
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
 
 
-#### fn matcher.withOptions
+#### fn byQuery.withProperty
 
 ```ts
-withOptions(value)
+withProperty(id, value)
 ```
 
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 
 
-### obj properties
+### obj byRegex
 
 
-#### fn properties.withId
+#### fn byRegex.new
 
 ```ts
-withId(value="")
+new(value)
 ```
 
+`new` creates a new override of type `%s`.
 
-
-#### fn properties.withValue
+#### fn byRegex.withPropertiesFromOptions
 
 ```ts
-withValue(value)
+withPropertiesFromOptions(options)
 ```
 
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byRegex.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byType
+
+
+#### fn byType.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byType.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byType.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
+
+
+### obj byValue
+
+
+#### fn byValue.new
+
+```ts
+new(value)
+```
+
+`new` creates a new override of type `%s`.
+
+#### fn byValue.withPropertiesFromOptions
+
+```ts
+withPropertiesFromOptions(options)
+```
+
+`withPropertiesFromOptions` takes an object with properties that need to be
+overridden. See example code above.
+
+
+#### fn byValue.withProperty
+
+```ts
+withProperty(id, value)
+```
+
+`withProperty` adds a property that needs to be overridden. This function can
+be called multiple time, adding more properties.
 

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -195,8 +195,8 @@ function(name, panel)
           ),
           withProperty(id, value):
             overrides.withPropertiesMixin([
-              overrides.property.withId(id)
-              + overrides.property.withValue(value),
+              overrides.properties.withId(id)
+              + overrides.properties.withValue(value),
             ]),
 
           '#withPropertiesFromOptions':: d.fn(

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -217,8 +217,8 @@ function(name, panel)
                     then infunc(input[p], path=path + [p])
                     else
                       overrides.withPropertiesMixin([
-                        overrides.property.withId(std.join('.', path + [p]))
-                        + overrides.property.withValue(input[p]),
+                        overrides.properties.withId(std.join('.', path + [p]))
+                        + overrides.properties.withValue(input[p]),
                       ])
                   ),
                 std.objectFields(input),

--- a/test/panel_test.jsonnet
+++ b/test/panel_test.jsonnet
@@ -26,3 +26,33 @@ test.new(std.thisFile)
     }
   )
 )
+
++ test.case.new(
+  name='Full fieldOverride test case (happy flow)',
+  test=test.expect.eq(
+    actual=
+    local fieldOverride = g.panel.timeSeries.fieldOverride;
+    local standardOptions = g.panel.timeSeries.standardOptions;
+    fieldOverride.byType.new('number')
+    + fieldOverride.byType.withProperty('unit', 's')
+    + fieldOverride.byType.withPropertiesFromOptions(
+      standardOptions.withDecimals(2)
+    ),
+    expected={
+      matcher: {
+        id: 'byType',
+        options: 'number',
+      },
+      properties: [
+        {
+          id: 'unit',
+          value: 's',
+        },
+        {
+          id: 'decimals',
+          value: 2,
+        },
+      ],
+    },
+  )
+)

--- a/test/panel_test.jsonnet
+++ b/test/panel_test.jsonnet
@@ -1,0 +1,28 @@
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+
+local g = import 'grafonnet-latest/main.libsonnet';
+
+test.new(std.thisFile)
++ test.case.new(
+  name='Ensure fieldOverride.<x>.withPropertiesFromOptions renders',
+  test=test.expect.eq(
+    actual=
+    local options =
+      g.panel.timeSeries.standardOptions.withDecimals(2)
+      + g.panel.timeSeries.fieldConfig.defaults.custom.withAxisLabel('aaa');
+
+    g.panel.timeSeries.fieldOverride.byName.withPropertiesFromOptions(options),
+    expected={
+      properties: [
+        {
+          id: 'custom.axisLabel',
+          value: 'aaa',
+        },
+        {
+          id: 'decimals',
+          value: 2,
+        },
+      ],
+    }
+  )
+)


### PR DESCRIPTION
Related to https://github.com/grafana/grafonnet/issues/39

The override objects are quite abstract as they reimplement the options from `fieldConfig`, this makes the raw/generated functions hard to use. This PR introduces veneer to construct `fieldOverride` objects including the different `matchers`. This is manual code as the matchers are not schematized. objects including the different `matchers`. This is manual code as the matchers are not schematized.