### PR TITLE
fix(veneer): always set schemaVersion on dashboard initialization

### DIFF
--- a/grafonnet-base/veneer/core.libsonnet
+++ b/grafonnet-base/veneer/core.libsonnet
@@ -13,6 +13,7 @@ local veneer = {
     ),
     new(title):
       self.withTitle(title)
+      + self.withSchemaVersion()
       + self.withTimezone('utc')
       + self.time.withFrom('now-6h')
       + self.time.withTo('now'),


### PR DESCRIPTION
title says it.

This came up in a support request, the `graphTooltip` was reset to the default value (`0`)
when the `schemaVersion` was missing on the dashboard.