### PR TITLE
docs: render docs for examples

### DIFF
--- a/docs.libsonnet
+++ b/docs.libsonnet
@@ -10,18 +10,18 @@ grafonnet.docs(
         'grafonnet',
         std.strReplace(importstr './README.md', '# Grafonnet', ''),
       ),
-    examples:: {
-      '#': d.package.newSub(
-        'examples',
-        |||
-          The repository holds several [examples](https://github.com/grafana/grafonnet/tree/main/examples), let's have a look at some of them.
-        |||
-        + '\n'
-        + std.join('\n', [
-          (import './examples/docs/simple.libsonnet'),
-          (import './examples/docs/composable.libsonnet'),
-        ])
-      ),
-    },
   }
 )
++ {
+  'examples.md':
+    |||
+      # Examples
+
+      The repository holds several [examples](https://github.com/grafana/grafonnet/tree/main/examples), let's have a look at some of them.
+    |||
+    + '\n'
+    + std.join('\n', [
+      (import './examples/docs/simple.libsonnet'),
+      (import './examples/docs/composable.libsonnet'),
+    ]),
+}

--- a/docs.libsonnet
+++ b/docs.libsonnet
@@ -10,5 +10,18 @@ grafonnet.docs(
         'grafonnet',
         std.strReplace(importstr './README.md', '# Grafonnet', ''),
       ),
+    examples:: {
+      '#': d.package.newSub(
+        'examples',
+        |||
+          The repository holds several [examples](https://github.com/grafana/grafonnet/tree/main/examples), let's have a look at some of them.
+        |||
+        + '\n'
+        + std.join('\n', [
+          (import './examples/docs/simple.libsonnet'),
+          (import './examples/docs/composable.libsonnet'),
+        ])
+      ),
+    },
   }
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,6 @@ jsonnet -J vendor dashboard.jsonnet
 ## Subpackages
 
 * [dashboard](grafonnet/dashboard.md)
-* [examples](grafonnet/examples.md)
 * [librarypanel](grafonnet/librarypanel.md)
 * [panel](grafonnet/panel.md)
 * [playlist](grafonnet/playlist.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ jsonnet -J vendor dashboard.jsonnet
 ## Subpackages
 
 * [dashboard](grafonnet/dashboard.md)
+* [examples](grafonnet/examples.md)
 * [librarypanel](grafonnet/librarypanel.md)
 * [panel](grafonnet/panel.md)
 * [playlist](grafonnet/playlist.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,4 +1,4 @@
-# examples
+# Examples
 
 The repository holds several [examples](https://github.com/grafana/grafonnet/tree/main/examples), let's have a look at some of them.
 
@@ -241,5 +241,3 @@ local var = g.dashboard.variable;
 ```
 
 The full controller runtime dashboard example can be [found in the repo](https://github.com/grafana/grafonnet/blob/master/examples/runtimeDashboard).
-
-

--- a/docs/grafonnet/examples.md
+++ b/docs/grafonnet/examples.md
@@ -1,0 +1,245 @@
+# examples
+
+The repository holds several [examples](https://github.com/grafana/grafonnet/tree/main/examples), let's have a look at some of them.
+
+## Simple dashboard
+
+This example shows a simple dashboard with a single panel displaying one query:
+
+```jsonnet
+local g = import 'g.libsonnet';
+
+g.dashboard.new('Faro dashboard')
++ g.dashboard.withUid('faro-grafonnet-demo')
++ g.dashboard.withDescription('Dashboard for Faro')
++ g.dashboard.graphTooltip.withSharedCrosshair()
++ g.dashboard.withPanels([
+  g.panel.timeSeries.new('Requests / sec')
+  + g.panel.timeSeries.queryOptions.withTargets([
+    g.query.prometheus.new(
+      'mimir',
+      'sum by (status_code) (rate(request_duration_seconds_count{job=~".*/faro-api"}[$__rate_interval]))',
+    ),
+  ])
+  + g.panel.timeSeries.standardOptions.withUnit('reqps')
+  + g.panel.timeSeries.gridPos.withW(24)
+  + g.panel.timeSeries.gridPos.withH(8),
+])
+```
+
+Note the `g.libsonnet` import at the top. The file contains the import reference to the actual version of Grafonnet being used, either latest or a more specific version. We do this to make the dashboard more portable. In this case we reference `grafonnet-latest`:
+
+```jsonnet
+import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet'
+```
+
+## Composable dashboard
+
+The [controller runtime dashboard](https://github.com/grafana/grafonnet/tree/duologic/docs_examples/examples/runtimeDashboard) example shows how we can compose a dashboard from reusable components. There are separate definitions of panels, variables and queries. The queries are combined with the panels and then the panels are grouped into rows. Eventually the panels and rows are rendered into a grid. Let's break it down.
+
+Similarly to the simple dashboard, Grafonnet is imported through `g.libsonnet` and `row` becomes a shortcut for the row panel. Additionally the panels, variables and queries get imported.
+
+```jsonnet
+local g = import 'g.libsonnet';
+
+local row = g.panel.row;
+
+local panels = import './panels.libsonnet';
+local variables = import './variables.libsonnet';
+local queries = import './queries.libsonnet';
+```
+
+The dashboard gets initialized with a title and description. The tooltip is configured to share a crosshair and tooltip on all panels.
+
+```jsonnet
+
+g.dashboard.new('Controller Runtime')
++ g.dashboard.withDescription(|||
+  Generic dashboard for controller-runtime based processes
+  (https://github.com/kubernetes-sigs/controller-runtime)
+|||)
++ g.dashboard.graphTooltip.withSharedCrosshair()
+```
+
+The variables get added to provide dropdowns for selecting the datasource, cluster, namespace and job values.
+
+```jsonnet
++ g.dashboard.withVariables([
+  variables.datasource,
+  variables.cluster,
+  variables.namespace,
+  variables.job,
+])
+```
+
+And eventually we'll add the panels. This examples makes use of the `makeGrid` util, this function will organize the panels on a grid with equal with panels. The grid is applied to each row.
+
+```jsonnet
++ g.dashboard.withPanels(
+  g.util.grid.makeGrid([
+    row.new('Process')
+    + row.withPanels([
+      panels.timeSeries.cpuUsage('CPU Usage', queries.cpuUsage),
+      panels.timeSeries.memoryUsage('Memory Usage', queries.memUsage),
+      panels.timeSeries.base('Goroutines', queries.goroutines),
+      panels.timeSeries.base('Threads', queries.threads),
+      panels.timeSeries.seconds('GC Duration Mean', queries.gcDuration),
+    ]),
+    row.new('Kubernetes Client')
+    + row.withPanels([
+      panels.heatmap.base('Workqueue Waiting Duration Over Time', queries.wqDurationOverTime),
+      panels.timeSeries.durationQuantile('Workqueue Waiting Duration Quantile', queries.wqDurationQuantile),
+      panels.timeSeries.short('Workqueue Depth', queries.wqDepth),
+      panels.timeSeries.short('Failed Requests', queries.failedRequests),
+    ]),
+    row.new('Controller Runtime')
+    + row.withPanels([
+      panels.heatmap.base('Reconciling Latency Over Time', queries.reconcilingLatencyOverTime),
+      panels.timeSeries.durationQuantile('Reconciling Latency Quantile', queries.reconcilingDurationQuantile),
+    ]),
+  ], panelWidth=8)
+)
+```
+
+### Panels
+
+The panels are defined separately from the queries, this turns them into reusable components. A panels can be called with a title and query. Let's take the 'Threads' panel as an example.
+
+```jsonnet
+panels.timeSeries.seconds('GC Duration Mean', queries.gcDuration),
+```
+
+The 'Threads' panels uses the `base` timeSeries panel. Reusing the same panel definition for this and other panels increases consistency. The shortcuts for `fieldOverride` etc. are intended to make the code more concise.
+
+```jsonnet
+// from panels.libsonnet
+local g = import 'g.libsonnet';
+
+{
+  timeseries: {
+    local timeSeries = g.panel.timeSeries,
+    local fieldOverride = g.panel.timeSeries.fieldOverride,
+    local custom = timeSeries.fieldConfig.defaults.custom,
+    local options = timeSeries.options,
+
+    base(title, targets):
+      timeSeries.new(title)
+      + timeSeries.queryOptions.withTargets(targets)
+      + timeSeries.queryOptions.withInterval('1m')
+      + options.legend.withDisplayMode('table')
+      + options.legend.withCalcs([
+        'lastNotNull',
+        'max',
+      ])
+      + custom.withFillOpacity(10)
+      + custom.withShowPoints('never'),
+  }
+}
+```
+
+The 'GC Duration Mean' panel extends the `base` panel to display the duration in seconds on a logarithmic scale. The `cpuUsage` panel is a shortcut to `seconds` panel.
+
+```jsonnet
+{
+  timeseries: {
+    seconds(title, targets):
+      self.base(title, targets)
+      + timeSeries.standardOptions.withUnit('s')
+      + custom.scaleDistribution.withType('log')
+      + custom.scaleDistribution.withLog(10),
+
+    cpuUsage: self.seconds,
+  }
+}
+```
+
+### Queries
+
+The queries are defined as separate objects. This allows us to swap out the Prometheus queries for Graphite queries while not having to change the dashboard. Additionally this makes it possible to reuse the queries on different panels or even in different dashboards.
+
+Letˋs take a look at a query definition. The `cpuUsage` is an instance of a `prometheusQuery`. Note that the query definition leans heavily on the variables, making the datasource configurable and using variables in the query expression, setting values for the cluster, namespace and job labels. Finally this configures a `legendFormat`, telling Grafana which values to show in the legend.
+
+```jsonnet
+// from queries.libsonnet
+local g = import './g.libsonnet';
+local prometheusQuery = g.query.prometheus;
+
+local variables = import './variables.libsonnet';
+
+{
+  cpuUsage:
+    prometheusQuery.new(
+      '$' + variables.datasource.name,
+      |||
+        sum by (cluster, namespace, job) (
+            rate(
+                process_cpu_seconds_total{
+                    cluster=~"$cluster",
+                    namespace=~"$namespace",
+                    job=~"$job"
+                }
+            [$__rate_interval])
+        )
+      |||
+    )
+    + prometheusQuery.withIntervalFactor(2)
+    + prometheusQuery.withLegendFormat(|||
+      {{cluster}} - {{namespace}}
+    |||),
+}
+
+### Variables
+
+To make this dashboard dynamic, it uses variables. This allows the user to select and manipulate the data being displayed.
+
+In this case there is a single 'datasource' variable and several 'query' variables. The 'query' variables depend on the datasource variable and then cascadingly depend on each other. This means that the values of for example `namespace` depend on the values from `datasource` and `cluster`.
+
+```jsonnet
+// variables.libsonnet
+local g = import './g.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  datasource:
+    var.datasource.new('datasource', 'prometheus')
+    + var.datasource.withRegex('(ops|dev)-cortex'),
+
+  cluster:
+    var.query.new('cluster')
+    + var.query.withDatasourceFromVariable(self.datasource)
+    + var.query.queryTypes.withLabelValues(
+      'cluster',
+      'process_cpu_seconds_total',
+    )
+    + var.query.withRefresh('time')
+    + var.query.selectionOptions.withMulti()
+    + var.query.selectionOptions.withIncludeAll(),
+
+  namespace:
+    var.query.new('namespace')
+    + var.query.withDatasourceFromVariable(self.datasource)
+    + var.query.queryTypes.withLabelValues(
+      'namespace',
+      'process_cpu_seconds_total{cluster=~"$%s"}' % self.cluster.name,
+    )
+    + var.query.withRefresh('time'),
+
+  job:
+    var.query.new('job')
+    + var.query.withDatasourceFromVariable(self.datasource)
+    + var.query.queryTypes.withLabelValues(
+      'job',
+      'process_cpu_seconds_total{cluster=~"$%s", namespace=~"$%s"}'
+      % [
+        self.cluster.name,
+        self.namespace.name,
+      ],
+    )
+    + var.query.withRefresh('time'),
+}
+
+```
+
+The full controller runtime dashboard example can be [found in the repo](https://github.com/grafana/grafonnet/blob/master/examples/runtimeDashboard).
+
+

--- a/docs/grafonnet/index.md
+++ b/docs/grafonnet/index.md
@@ -1,6 +1,7 @@
 # grafonnet
 
 * [dashboard](dashboard.md)
+* [examples](examples.md)
 * [librarypanel](librarypanel.md)
 * [panel](panel.md)
 * [playlist](playlist.md)

--- a/docs/grafonnet/index.md
+++ b/docs/grafonnet/index.md
@@ -1,7 +1,6 @@
 # grafonnet
 
 * [dashboard](dashboard.md)
-* [examples](examples.md)
 * [librarypanel](librarypanel.md)
 * [panel](panel.md)
 * [playlist](playlist.md)

--- a/docs/grafonnet/panel/alertGroups/fieldOverride.md
+++ b/docs/grafonnet/panel/alertGroups/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/annotationsList/fieldOverride.md
+++ b/docs/grafonnet/panel/annotationsList/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/barChart/fieldOverride.md
+++ b/docs/grafonnet/panel/barChart/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/barGauge/fieldOverride.md
+++ b/docs/grafonnet/panel/barGauge/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/candlestick/fieldOverride.md
+++ b/docs/grafonnet/panel/candlestick/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/canvas/fieldOverride.md
+++ b/docs/grafonnet/panel/canvas/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/dashboardList/fieldOverride.md
+++ b/docs/grafonnet/panel/dashboardList/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/debug/fieldOverride.md
+++ b/docs/grafonnet/panel/debug/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/gauge/fieldOverride.md
+++ b/docs/grafonnet/panel/gauge/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/geomap/fieldOverride.md
+++ b/docs/grafonnet/panel/geomap/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/heatmap/fieldOverride.md
+++ b/docs/grafonnet/panel/heatmap/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/histogram/fieldOverride.md
+++ b/docs/grafonnet/panel/histogram/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/logs/fieldOverride.md
+++ b/docs/grafonnet/panel/logs/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/news/fieldOverride.md
+++ b/docs/grafonnet/panel/news/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/nodeGraph/fieldOverride.md
+++ b/docs/grafonnet/panel/nodeGraph/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/pieChart/fieldOverride.md
+++ b/docs/grafonnet/panel/pieChart/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/stat/fieldOverride.md
+++ b/docs/grafonnet/panel/stat/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/stateTimeline/fieldOverride.md
+++ b/docs/grafonnet/panel/stateTimeline/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/statusHistory/fieldOverride.md
+++ b/docs/grafonnet/panel/statusHistory/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/table/fieldOverride.md
+++ b/docs/grafonnet/panel/table/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/text/fieldOverride.md
+++ b/docs/grafonnet/panel/text/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/timeSeries/fieldOverride.md
+++ b/docs/grafonnet/panel/timeSeries/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/docs/grafonnet/panel/xyChart/fieldOverride.md
+++ b/docs/grafonnet/panel/xyChart/fieldOverride.md
@@ -23,10 +23,10 @@ fieldOverride.byType.new('number')
   * [`fn new(value)`](#fn-byquerynew)
   * [`fn withPropertiesFromOptions(options)`](#fn-byquerywithpropertiesfromoptions)
   * [`fn withProperty(id, value)`](#fn-byquerywithproperty)
-* [`obj byRegex`](#obj-byregex)
-  * [`fn new(value)`](#fn-byregexnew)
-  * [`fn withPropertiesFromOptions(options)`](#fn-byregexwithpropertiesfromoptions)
-  * [`fn withProperty(id, value)`](#fn-byregexwithproperty)
+* [`obj byRegexp`](#obj-byregexp)
+  * [`fn new(value)`](#fn-byregexpnew)
+  * [`fn withPropertiesFromOptions(options)`](#fn-byregexpwithpropertiesfromoptions)
+  * [`fn withProperty(id, value)`](#fn-byregexpwithproperty)
 * [`obj byType`](#obj-bytype)
   * [`fn new(value)`](#fn-bytypenew)
   * [`fn withPropertiesFromOptions(options)`](#fn-bytypewithpropertiesfromoptions)
@@ -100,18 +100,18 @@ withProperty(id, value)
 be called multiple time, adding more properties.
 
 
-### obj byRegex
+### obj byRegexp
 
 
-#### fn byRegex.new
+#### fn byRegexp.new
 
 ```ts
 new(value)
 ```
 
-`new` creates a new override of type `byRegex`.
+`new` creates a new override of type `byRegexp`.
 
-#### fn byRegex.withPropertiesFromOptions
+#### fn byRegexp.withPropertiesFromOptions
 
 ```ts
 withPropertiesFromOptions(options)
@@ -121,7 +121,7 @@ withPropertiesFromOptions(options)
 overridden. See example code above.
 
 
-#### fn byRegex.withProperty
+#### fn byRegexp.withProperty
 
 ```ts
 withProperty(id, value)

--- a/examples/docs/composable.libsonnet
+++ b/examples/docs/composable.libsonnet
@@ -1,0 +1,131 @@
+local fileSnippet = (import './helpers.libsonnet').fileSnippet;
+
+|||
+  ## Composable dashboard
+
+  The [controller runtime dashboard](https://github.com/grafana/grafonnet/tree/duologic/docs_examples/examples/runtimeDashboard) example shows how we can compose a dashboard from reusable components. There are separate definitions of panels, variables and queries. The queries are combined with the panels and then the panels are grouped into rows. Eventually the panels and rows are rendered into a grid. Let's break it down.
+
+  Similarly to the simple dashboard, Grafonnet is imported through `g.libsonnet` and `row` becomes a shortcut for the row panel. Additionally the panels, variables and queries get imported.
+
+  ```jsonnet
+  %(main_imports)s
+  ```
+
+  The dashboard gets initialized with a title and description. The tooltip is configured to share a crosshair and tooltip on all panels.
+
+  ```jsonnet
+  %(main_init)s
+  ```
+
+  The variables get added to provide dropdowns for selecting the datasource, cluster, namespace and job values.
+
+  ```jsonnet
+  %(main_variables)s
+  ```
+
+  And eventually we'll add the panels. This examples makes use of the `makeGrid` util, this function will organize the panels on a grid with equal with panels. The grid is applied to each row.
+
+  ```jsonnet
+  %(main_panels)s
+  ```
+
+  ### Panels
+
+  The panels are defined separately from the queries, this turns them into reusable components. A panels can be called with a title and query. Let's take the 'Threads' panel as an example.
+
+  ```jsonnet
+  %(main_panelcall)s
+  ```
+
+  The 'Threads' panels uses the `base` timeSeries panel. Reusing the same panel definition for this and other panels increases consistency. The shortcuts for `fieldOverride` etc. are intended to make the code more concise.
+
+  ```jsonnet
+  // from panels.libsonnet
+  %(timeseries_imports)s
+
+  {
+    timeseries: {
+  %(timeseries_shortcuts)s
+
+  %(timeseries_base)s
+    }
+  }
+  ```
+
+  The 'GC Duration Mean' panel extends the `base` panel to display the duration in seconds on a logarithmic scale. The `cpuUsage` panel is a shortcut to `seconds` panel.
+
+  ```jsonnet
+  {
+    timeseries: {
+  %(timeseries_seconds)s
+    }
+  }
+  ```
+
+  ### Queries
+
+  The queries are defined as separate objects. This allows us to swap out the Prometheus queries for Graphite queries while not having to change the dashboard. Additionally this makes it possible to reuse the queries on different panels or even in different dashboards.
+
+  Letˋs take a look at a query definition. The `cpuUsage` is an instance of a `prometheusQuery`. Note that the query definition leans heavily on the variables, making the datasource configurable and using variables in the query expression, setting values for the cluster, namespace and job labels. Finally this configures a `legendFormat`, telling Grafana which values to show in the legend.
+
+  ```jsonnet
+  // from queries.libsonnet
+  %(queries_locals)s
+
+  {
+  %(queries_query)s
+  }
+
+  ### Variables
+
+  To make this dashboard dynamic, it uses variables. This allows the user to select and manipulate the data being displayed.
+
+  In this case there is a single 'datasource' variable and several 'query' variables. The 'query' variables depend on the datasource variable and then cascadingly depend on each other. This means that the values of for example `namespace` depend on the values from `datasource` and `cluster`.
+
+  ```jsonnet
+  // variables.libsonnet
+  %(variables.libsonnet)s
+  ```
+
+  The full controller runtime dashboard example can be [found in the repo](https://github.com/grafana/grafonnet/blob/master/examples/runtimeDashboard).
+||| % {
+  local main = importstr './../runtimeDashboard/main.libsonnet',
+  main_imports: fileSnippet.lines(main, 0, 7),
+  main_init: fileSnippet.lines(main, 7, 14),
+  main_variables: fileSnippet.lines(main, 14, 20),
+  main_panels: fileSnippet.lines(main, 20, 44),
+  main_panelcall: fileSnippet.lines(main, 28, 29, 6),
+
+  local panels = importstr './../runtimeDashboard/panels.libsonnet',
+  timeseries_imports:
+    fileSnippet.lines(panels, 0, 1),
+
+  timeseries_shortcuts:
+    fileSnippet.find(
+      panels,
+      'local timeSeries = g.panel.timeSeries,',
+      'local options = timeSeries.options,',
+    ),
+  timeseries_base:
+    fileSnippet.find(
+      panels,
+      'base(title, targets):',
+      "+ custom.withShowPoints('never'),",
+    ),
+  timeseries_seconds:
+    fileSnippet.find(
+      panels,
+      'seconds(title, targets):',
+      'cpuUsage: self.seconds,',
+    ),
+
+  local queries = importstr './../runtimeDashboard/queries.libsonnet',
+  queries_locals: fileSnippet.lines(queries, 0, 4),
+  queries_query: fileSnippet.find(
+    queries,
+    'cpuUsage:',
+    '|||),',
+  ),
+
+  'variables.libsonnet': importstr './../runtimeDashboard/variables.libsonnet',
+}

--- a/examples/docs/helpers.libsonnet
+++ b/examples/docs/helpers.libsonnet
@@ -1,0 +1,24 @@
+{
+  fileSnippet: {
+    find(file, startLine, endLine, reduceIndentSpaces=0):
+      local lines = std.split(file, '\n');
+      local searchlines = [std.stripChars(l, ' ') for l in lines];
+      local startIndex = std.find(startLine, searchlines);
+      local endIndex = std.find(endLine, searchlines);
+      assert std.length(startIndex) > 0 : '`startLine` not found';
+      assert std.length(endIndex) > 0 : '`endLine` not found';
+
+      local output = lines[startIndex[0]:(endIndex[0] + 1)];
+      std.join('\n', [
+        l[reduceIndentSpaces:]
+        for l in output
+      ]),
+
+    lines(file, startNum, endNum, reduceIndentSpaces=0):
+      local lines = std.split(file, '\n');
+      std.join('\n', [
+        l[reduceIndentSpaces:]
+        for l in lines[startNum:endNum]
+      ]),
+  },
+}

--- a/examples/docs/simple.libsonnet
+++ b/examples/docs/simple.libsonnet
@@ -1,0 +1,16 @@
+|||
+  ## Simple dashboard
+
+  This example shows a simple dashboard with a single panel displaying one query:
+
+  ```jsonnet
+  %(main.libsonnet)s```
+
+  Note the `g.libsonnet` import at the top. The file contains the import reference to the actual version of Grafonnet being used, either latest or a more specific version. We do this to make the dashboard more portable. In this case we reference `grafonnet-latest`:
+
+  ```jsonnet
+  %(g.libsonnet)s```
+||| % {
+  'main.libsonnet': importstr './../simple/main.libsonnet',
+  'g.libsonnet': importstr './../simple/g.libsonnet',
+}

--- a/examples/runtimeDashboard/g.libsonnet
+++ b/examples/runtimeDashboard/g.libsonnet
@@ -1,1 +1,1 @@
-import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonnet'
+import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet'

--- a/examples/runtimeDashboard/jsonnetfile.json
+++ b/examples/runtimeDashboard/jsonnetfile.json
@@ -5,7 +5,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v9.4.0"
+          "subdir": "gen/grafonnet-latest"
         }
       },
       "version": "main"

--- a/examples/runtimeDashboard/main.libsonnet
+++ b/examples/runtimeDashboard/main.libsonnet
@@ -1,4 +1,4 @@
-local g = import './g.libsonnet';
+local g = import 'g.libsonnet';
 
 local row = g.panel.row;
 
@@ -42,5 +42,3 @@ g.dashboard.new('Controller Runtime')
     ]),
   ], panelWidth=8)
 )
-
-// vim: foldmethod=marker foldmarker=local,;

--- a/examples/runtimeDashboard/panels.libsonnet
+++ b/examples/runtimeDashboard/panels.libsonnet
@@ -1,18 +1,16 @@
-local g = import './g.libsonnet';
+local g = import 'g.libsonnet';
 
 {
   timeSeries: {
     local timeSeries = g.panel.timeSeries,
-    local fieldConfig = timeSeries.fieldConfig,
-    local defaults = timeSeries.fieldConfig.defaults,
+    local fieldOverride = g.panel.timeSeries.fieldOverride,
     local custom = timeSeries.fieldConfig.defaults.custom,
-    local override = timeSeries.fieldConfig.overrides,
     local options = timeSeries.options,
 
     base(title, targets):
       timeSeries.new(title)
-      + timeSeries.withTargets(targets)
-      + timeSeries.withInterval('1m')
+      + timeSeries.queryOptions.withTargets(targets)
+      + timeSeries.queryOptions.withInterval('1m')
       + options.legend.withDisplayMode('table')
       + options.legend.withCalcs([
         'lastNotNull',
@@ -23,57 +21,61 @@ local g = import './g.libsonnet';
 
     short(title, targets):
       self.base(title, targets)
-      + defaults.withUnit('short')
-      + defaults.withDecimals(0),
+      + timeSeries.standardOptions.withUnit('short')
+      + timeSeries.standardOptions.withDecimals(0),
 
     seconds(title, targets):
       self.base(title, targets)
-      + defaults.withUnit('s')
+      + timeSeries.standardOptions.withUnit('s')
       + custom.scaleDistribution.withType('log')
       + custom.scaleDistribution.withLog(10),
 
+    cpuUsage: self.seconds,
+
     bytes(title, targets):
       self.base(title, targets,)
-      + defaults.withUnit('bytes')
+      + timeSeries.standardOptions.withUnit('bytes')
       + custom.scaleDistribution.withType('log')
       + custom.scaleDistribution.withLog(2),
 
-    cpuUsage: self.seconds,
-
     memoryUsage(title, targets):
       self.bytes(title, targets)
-      + fieldConfig.withOverrides([
-        override.matcher.withId('byRegexp')
-        + override.matcher.withOptions('/(virtual|resident)/i')
-        + override.withProperties([
-          override.properties.withId('custom.fillOpacity')
-          + override.properties.withValue(0),
-          override.properties.withId('custom.lineWidth')
-          + override.properties.withValue(2),
-          override.properties.withId('custom.lineStyle')
-          + override.properties.withValue({
+      + timeSeries.standardOptions.withOverrides([
+        fieldOverride.byRegex.new('/(virtual|resident)/i')
+        + fieldOverride.byRegex.withProperty(
+          'custom.fillOpacity',
+          0
+        )
+        + fieldOverride.byRegex.withProperty(
+          'custom.lineWidth',
+          2
+        )
+        + fieldOverride.byRegex.withProperty(
+          'custom.lineStyle',
+          {
             dash: [10, 10],
             fill: 'dash',
-          }),
-        ]),
+          }
+        ),
       ]),
 
     durationQuantile(title, targets):
       self.base(title, targets)
-      + defaults.withUnit('s')
+      + timeSeries.standardOptions.withUnit('s')
       + custom.withDrawStyle('bars')
-      + fieldConfig.withOverrides([
-        override.matcher.withId('byRegexp')
-        + override.matcher.withOptions('/mean/i')
-        + override.withProperties([
-          override.properties.withId('custom.fillOpacity')
-          + override.properties.withValue(0),
-          override.properties.withId('custom.lineStyle')
-          + override.properties.withValue({
+      + timeSeries.standardOptions.withOverrides([
+        fieldOverride.byRegex.new('/mean/i')
+        + fieldOverride.byRegex.withProperty(
+          'custom.fillOpacity',
+          0
+        )
+        + fieldOverride.byRegex.withProperty(
+          'custom.lineStyle',
+          {
             dash: [8, 10],
             fill: 'dash',
-          }),
-        ]),
+          }
+        ),
       ]),
   },
 
@@ -83,19 +85,18 @@ local g = import './g.libsonnet';
 
     base(title, targets):
       heatmap.new(title)
-      + heatmap.withTargets(targets)
-      + heatmap.withInterval('1m'),
-    // heatmap.options not schematized yet
-    // + options.withCalculate()
-    // + options.calculation.xBuckets.withMode('size')
-    // + options.calculation.xBuckets.withValue('1min')
-    // + options.withCellGep(2)
-    // + options.color.withMode('scheme')
-    // + options.color.withScheme('Spectral')
-    // + options.color.withSteps(128)
-    // + options.yAxis.withDecimals(0)
-    // + options.yAxis.withUnit('s')
+      + heatmap.queryOptions.withTargets(targets)
+      + heatmap.queryOptions.withInterval('1m')
+      + options.withCalculate()
+      + options.calculation.xBuckets.withMode('size')
+      + options.calculation.xBuckets.withValue('1min')
+      + options.withCellGap(2)
+      + options.color.HeatmapColorOptions.withMode('scheme')
+      + options.color.HeatmapColorOptions.withScheme('Spectral')
+      + options.color.HeatmapColorOptions.withSteps(128)
+      + options.yAxis.withDecimals(0)
+      + options.yAxis.withUnit('s'),
   },
 }
 
-// vim: foldmethod=indent shiftwidth=2 foldlevel=2
+// vim: foldmethod=marker foldmarker=local,;

--- a/examples/simple/g.libsonnet
+++ b/examples/simple/g.libsonnet
@@ -1,1 +1,1 @@
-import 'github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main.libsonnet'
+import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet'

--- a/examples/simple/jsonnetfile.json
+++ b/examples/simple/jsonnetfile.json
@@ -5,7 +5,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v9.4.0"
+          "subdir": "gen/grafonnet-latest"
         }
       },
       "version": "main"

--- a/examples/simple/main.libsonnet
+++ b/examples/simple/main.libsonnet
@@ -6,13 +6,13 @@ g.dashboard.new('Faro dashboard')
 + g.dashboard.graphTooltip.withSharedCrosshair()
 + g.dashboard.withPanels([
   g.panel.timeSeries.new('Requests / sec')
-  + g.panel.timeSeries.withTargets([
+  + g.panel.timeSeries.queryOptions.withTargets([
     g.query.prometheus.new(
-      'ops-cortex',
+      'mimir',
       'sum by (status_code) (rate(request_duration_seconds_count{job=~".*/faro-api"}[$__rate_interval]))',
     ),
   ])
-  + g.panel.timeSeries.fieldConfig.defaults.withUnit('reqps')
+  + g.panel.timeSeries.standardOptions.withUnit('reqps')
   + g.panel.timeSeries.gridPos.withW(24)
   + g.panel.timeSeries.gridPos.withH(8),
 ])

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -149,7 +149,7 @@ function(name, panel)
     fieldOverride:
       local matchers = [
         'byName',
-        'byRegex',
+        'byRegexp',
         'byType',
         'byQuery',
         'byValue',  // TODO: byValue takes more complex `options` than string


### PR DESCRIPTION
This PR adds a page explaining two of the examples. This should make it more accessible to
a wider audience.