### PR TITLE
fix: typo in tresholds -> thresholds

### DIFF
--- a/docs/API/panel/alertGroups/index.md
+++ b/docs/API/panel/alertGroups/index.md
@@ -65,10 +65,10 @@ grafonnet.panel.alertGroups
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -467,10 +467,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -480,7 +480,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -488,7 +488,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/annotationsList/index.md
+++ b/docs/API/panel/annotationsList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.annotationsList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/barChart/index.md
+++ b/docs/API/panel/barChart/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.barChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/barGauge/index.md
+++ b/docs/API/panel/barGauge/index.md
@@ -81,10 +81,10 @@ grafonnet.panel.barGauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -608,10 +608,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -621,7 +621,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -629,7 +629,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/candlestick/index.md
+++ b/docs/API/panel/candlestick/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.candlestick
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/canvas/index.md
+++ b/docs/API/panel/canvas/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.canvas
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/dashboardList/index.md
+++ b/docs/API/panel/dashboardList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.dashboardList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/datagrid/index.md
+++ b/docs/API/panel/datagrid/index.md
@@ -63,10 +63,10 @@ grafonnet.panel.datagrid
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -449,10 +449,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -462,7 +462,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -470,7 +470,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/debug/index.md
+++ b/docs/API/panel/debug/index.md
@@ -69,10 +69,10 @@ grafonnet.panel.debug
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -500,10 +500,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -513,7 +513,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -521,7 +521,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/gauge/index.md
+++ b/docs/API/panel/gauge/index.md
@@ -78,10 +78,10 @@ grafonnet.panel.gauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -576,10 +576,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -589,7 +589,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -597,7 +597,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/geomap/index.md
+++ b/docs/API/panel/geomap/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.geomap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/heatmap/index.md
+++ b/docs/API/panel/heatmap/index.md
@@ -177,10 +177,10 @@ grafonnet.panel.heatmap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1390,10 +1390,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1403,7 +1403,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1411,7 +1411,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/histogram/index.md
+++ b/docs/API/panel/histogram/index.md
@@ -109,10 +109,10 @@ grafonnet.panel.histogram
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -844,10 +844,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -857,7 +857,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -865,7 +865,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/logs/index.md
+++ b/docs/API/panel/logs/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.logs
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -516,10 +516,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -529,7 +529,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -537,7 +537,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/news/index.md
+++ b/docs/API/panel/news/index.md
@@ -64,10 +64,10 @@ grafonnet.panel.news
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -458,10 +458,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -471,7 +471,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -479,7 +479,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/nodeGraph/index.md
+++ b/docs/API/panel/nodeGraph/index.md
@@ -77,10 +77,10 @@ grafonnet.panel.nodeGraph
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -560,10 +560,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -573,7 +573,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -581,7 +581,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/pieChart/index.md
+++ b/docs/API/panel/pieChart/index.md
@@ -108,10 +108,10 @@ grafonnet.panel.pieChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -827,10 +827,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -840,7 +840,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -848,7 +848,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/stat/index.md
+++ b/docs/API/panel/stat/index.md
@@ -80,10 +80,10 @@ grafonnet.panel.stat
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -602,10 +602,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -615,7 +615,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -623,7 +623,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/stateTimeline/index.md
+++ b/docs/API/panel/stateTimeline/index.md
@@ -97,10 +97,10 @@ grafonnet.panel.stateTimeline
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -734,10 +734,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -747,7 +747,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -755,7 +755,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/statusHistory/index.md
+++ b/docs/API/panel/statusHistory/index.md
@@ -96,10 +96,10 @@ grafonnet.panel.statusHistory
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -725,10 +725,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -738,7 +738,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -746,7 +746,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/table/index.md
+++ b/docs/API/panel/table/index.md
@@ -84,10 +84,10 @@ grafonnet.panel.table
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -623,10 +623,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -636,7 +636,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -644,7 +644,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/text/index.md
+++ b/docs/API/panel/text/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.text
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -511,10 +511,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -524,7 +524,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -532,7 +532,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/timeSeries/index.md
+++ b/docs/API/panel/timeSeries/index.md
@@ -138,10 +138,10 @@ grafonnet.panel.timeSeries
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1111,10 +1111,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1124,7 +1124,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1132,7 +1132,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/trend/index.md
+++ b/docs/API/panel/trend/index.md
@@ -137,10 +137,10 @@ grafonnet.panel.trend
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1102,10 +1102,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1115,7 +1115,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1123,7 +1123,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/docs/API/panel/xyChart/index.md
+++ b/docs/API/panel/xyChart/index.md
@@ -147,10 +147,10 @@ grafonnet.panel.xyChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1177,10 +1177,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1190,7 +1190,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1198,7 +1198,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/index.md
@@ -65,10 +65,10 @@ grafonnet.panel.alertGroups
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -467,10 +467,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -480,7 +480,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -488,7 +488,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.annotationsList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.barChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/index.md
@@ -81,10 +81,10 @@ grafonnet.panel.barGauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -608,10 +608,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -621,7 +621,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -629,7 +629,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.candlestick
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.canvas
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.dashboardList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/index.md
@@ -63,10 +63,10 @@ grafonnet.panel.datagrid
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -449,10 +449,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -462,7 +462,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -470,7 +470,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/index.md
@@ -69,10 +69,10 @@ grafonnet.panel.debug
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -500,10 +500,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -513,7 +513,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -521,7 +521,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/index.md
@@ -78,10 +78,10 @@ grafonnet.panel.gauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -576,10 +576,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -589,7 +589,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -597,7 +597,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.geomap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/index.md
@@ -177,10 +177,10 @@ grafonnet.panel.heatmap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1390,10 +1390,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1403,7 +1403,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1411,7 +1411,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/index.md
@@ -109,10 +109,10 @@ grafonnet.panel.histogram
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -844,10 +844,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -857,7 +857,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -865,7 +865,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.logs
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -516,10 +516,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -529,7 +529,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -537,7 +537,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/index.md
@@ -64,10 +64,10 @@ grafonnet.panel.news
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -458,10 +458,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -471,7 +471,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -479,7 +479,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -77,10 +77,10 @@ grafonnet.panel.nodeGraph
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -560,10 +560,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -573,7 +573,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -581,7 +581,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/index.md
@@ -108,10 +108,10 @@ grafonnet.panel.pieChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -827,10 +827,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -840,7 +840,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -848,7 +848,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/index.md
@@ -80,10 +80,10 @@ grafonnet.panel.stat
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -602,10 +602,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -615,7 +615,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -623,7 +623,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -97,10 +97,10 @@ grafonnet.panel.stateTimeline
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -734,10 +734,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -747,7 +747,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -755,7 +755,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/index.md
@@ -96,10 +96,10 @@ grafonnet.panel.statusHistory
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -725,10 +725,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -738,7 +738,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -746,7 +746,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/index.md
@@ -84,10 +84,10 @@ grafonnet.panel.table
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -623,10 +623,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -636,7 +636,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -644,7 +644,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.text
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -511,10 +511,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -524,7 +524,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -532,7 +532,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/index.md
@@ -138,10 +138,10 @@ grafonnet.panel.timeSeries
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1111,10 +1111,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1124,7 +1124,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1132,7 +1132,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/index.md
@@ -137,10 +137,10 @@ grafonnet.panel.trend
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1102,10 +1102,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1115,7 +1115,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1123,7 +1123,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/index.md
@@ -147,10 +147,10 @@ grafonnet.panel.xyChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1177,10 +1177,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1190,7 +1190,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1198,7 +1198,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/index.md
@@ -65,10 +65,10 @@ grafonnet.panel.alertGroups
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -467,10 +467,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -480,7 +480,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -488,7 +488,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.annotationsList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.barChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1007,10 +1007,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1020,7 +1020,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1028,7 +1028,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/index.md
@@ -81,10 +81,10 @@ grafonnet.panel.barGauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -608,10 +608,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -621,7 +621,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -629,7 +629,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.candlestick
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.canvas
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/index.md
@@ -72,10 +72,10 @@ grafonnet.panel.dashboardList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -532,10 +532,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -545,7 +545,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -553,7 +553,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/index.md
@@ -69,10 +69,10 @@ grafonnet.panel.debug
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -500,10 +500,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -513,7 +513,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -521,7 +521,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/index.md
@@ -78,10 +78,10 @@ grafonnet.panel.gauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -576,10 +576,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -589,7 +589,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -597,7 +597,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.geomap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/index.md
@@ -177,10 +177,10 @@ grafonnet.panel.heatmap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1389,10 +1389,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1402,7 +1402,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1410,7 +1410,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/index.md
@@ -109,10 +109,10 @@ grafonnet.panel.histogram
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -845,10 +845,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -858,7 +858,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -866,7 +866,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.logs
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -516,10 +516,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -529,7 +529,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -537,7 +537,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/index.md
@@ -64,10 +64,10 @@ grafonnet.panel.news
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -458,10 +458,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -471,7 +471,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -479,7 +479,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -77,10 +77,10 @@ grafonnet.panel.nodeGraph
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -560,10 +560,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -573,7 +573,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -581,7 +581,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/index.md
@@ -108,10 +108,10 @@ grafonnet.panel.pieChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -827,10 +827,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -840,7 +840,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -848,7 +848,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/index.md
@@ -80,10 +80,10 @@ grafonnet.panel.stat
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -602,10 +602,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -615,7 +615,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -623,7 +623,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -97,10 +97,10 @@ grafonnet.panel.stateTimeline
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -738,10 +738,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -751,7 +751,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -759,7 +759,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/index.md
@@ -96,10 +96,10 @@ grafonnet.panel.statusHistory
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -727,10 +727,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -740,7 +740,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -748,7 +748,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/index.md
@@ -85,10 +85,10 @@ grafonnet.panel.table
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -634,10 +634,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -647,7 +647,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -655,7 +655,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.text
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -511,10 +511,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -524,7 +524,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -532,7 +532,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/index.md
@@ -136,10 +136,10 @@ grafonnet.panel.timeSeries
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1093,10 +1093,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1106,7 +1106,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1114,7 +1114,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/index.md
@@ -150,10 +150,10 @@ grafonnet.panel.xyChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1202,10 +1202,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1215,7 +1215,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1223,7 +1223,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/index.md
@@ -65,10 +65,10 @@ grafonnet.panel.alertGroups
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -467,10 +467,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -480,7 +480,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -488,7 +488,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/index.md
@@ -73,10 +73,10 @@ grafonnet.panel.annotationsList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -539,10 +539,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -552,7 +552,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -560,7 +560,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.barChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1007,10 +1007,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1020,7 +1020,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1028,7 +1028,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/index.md
@@ -81,10 +81,10 @@ grafonnet.panel.barGauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -608,10 +608,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -621,7 +621,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -629,7 +629,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.candlestick
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/index.md
@@ -61,10 +61,10 @@ grafonnet.panel.canvas
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -436,10 +436,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -449,7 +449,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -457,7 +457,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/index.md
@@ -72,10 +72,10 @@ grafonnet.panel.dashboardList
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -532,10 +532,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -545,7 +545,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -553,7 +553,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/index.md
@@ -69,10 +69,10 @@ grafonnet.panel.debug
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -500,10 +500,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -513,7 +513,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -521,7 +521,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/index.md
@@ -78,10 +78,10 @@ grafonnet.panel.gauge
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -576,10 +576,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -589,7 +589,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -597,7 +597,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/index.md
@@ -127,10 +127,10 @@ grafonnet.panel.geomap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1000,10 +1000,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1013,7 +1013,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1021,7 +1021,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/index.md
@@ -177,10 +177,10 @@ grafonnet.panel.heatmap
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1389,10 +1389,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1402,7 +1402,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1410,7 +1410,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/index.md
@@ -109,10 +109,10 @@ grafonnet.panel.histogram
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -845,10 +845,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -858,7 +858,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -866,7 +866,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.logs
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -516,10 +516,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -529,7 +529,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -537,7 +537,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/index.md
@@ -64,10 +64,10 @@ grafonnet.panel.news
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -458,10 +458,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -471,7 +471,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -479,7 +479,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -77,10 +77,10 @@ grafonnet.panel.nodeGraph
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -560,10 +560,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -573,7 +573,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -581,7 +581,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/index.md
@@ -108,10 +108,10 @@ grafonnet.panel.pieChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -827,10 +827,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -840,7 +840,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -848,7 +848,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/index.md
@@ -80,10 +80,10 @@ grafonnet.panel.stat
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -602,10 +602,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -615,7 +615,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -623,7 +623,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -97,10 +97,10 @@ grafonnet.panel.stateTimeline
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -738,10 +738,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -751,7 +751,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -759,7 +759,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/index.md
@@ -96,10 +96,10 @@ grafonnet.panel.statusHistory
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -727,10 +727,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -740,7 +740,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -748,7 +748,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/index.md
@@ -84,10 +84,10 @@ grafonnet.panel.table
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -625,10 +625,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -638,7 +638,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -646,7 +646,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/index.md
@@ -70,10 +70,10 @@ grafonnet.panel.text
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -511,10 +511,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -524,7 +524,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -532,7 +532,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/index.md
@@ -138,10 +138,10 @@ grafonnet.panel.timeSeries
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1111,10 +1111,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1124,7 +1124,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1132,7 +1132,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/index.md
@@ -150,10 +150,10 @@ grafonnet.panel.xyChart
     * [`fn withFixedColor(value)`](#fn-standardoptionscolorwithfixedcolor)
     * [`fn withMode(value)`](#fn-standardoptionscolorwithmode)
     * [`fn withSeriesBy(value)`](#fn-standardoptionscolorwithseriesby)
-  * [`obj tresholds`](#obj-standardoptionstresholds)
-    * [`fn withMode(value)`](#fn-standardoptionstresholdswithmode)
-    * [`fn withSteps(value)`](#fn-standardoptionstresholdswithsteps)
-    * [`fn withStepsMixin(value)`](#fn-standardoptionstresholdswithstepsmixin)
+  * [`obj thresholds`](#obj-standardoptionsthresholds)
+    * [`fn withMode(value)`](#fn-standardoptionsthresholdswithmode)
+    * [`fn withSteps(value)`](#fn-standardoptionsthresholdswithsteps)
+    * [`fn withStepsMixin(value)`](#fn-standardoptionsthresholdswithstepsmixin)
 
 ## Fields
 
@@ -1202,10 +1202,10 @@ TODO docs
 
 Accepted values for `value` are "min", "max", "last"
 
-#### obj standardOptions.tresholds
+#### obj standardOptions.thresholds
 
 
-##### fn standardOptions.tresholds.withMode
+##### fn standardOptions.thresholds.withMode
 
 ```ts
 withMode(value)
@@ -1215,7 +1215,7 @@ withMode(value)
 
 Accepted values for `value` are "absolute", "percentage"
 
-##### fn standardOptions.tresholds.withSteps
+##### fn standardOptions.thresholds.withSteps
 
 ```ts
 withSteps(value)
@@ -1223,7 +1223,7 @@ withSteps(value)
 
 Must be sorted by 'value', first value is always -Infinity
 
-##### fn standardOptions.tresholds.withStepsMixin
+##### fn standardOptions.thresholds.withStepsMixin
 
 ```ts
 withStepsMixin(value)

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -46,7 +46,7 @@ local groupings = {
     'fieldConfig.withOverridesMixin',
   ],
 
-  'standardOptions.tresholds': [
+  'standardOptions.thresholds': [
     'fieldConfig.defaults.thresholds.withMode',
     'fieldConfig.defaults.thresholds.withSteps',
     'fieldConfig.defaults.thresholds.withStepsMixin',


### PR DESCRIPTION
Changed `standardOptions.tresholds` to `standardOptions.thresholds` and ran `make docs` afterwards.