### PR TITLE
fix: only recurse when key == 'custom' in withPropertiesFromOptions

### DIFF
--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -204,22 +204,16 @@ function(name, panel)
             ]
           ),
           withPropertiesFromOptions(options):
-            local infunc(input, path=[]) =
-              std.foldl(
-                function(acc, p)
-                  acc + (
-                    if std.isObject(input[p])
-                    then infunc(input[p], path=path + [p])
-                    else
-                      overrides.withPropertiesMixin([
-                        overrides.properties.withId(std.join('.', path + [p]))
-                        + overrides.properties.withValue(input[p]),
-                      ])
-                  ),
-                std.objectFields(input),
-                {}
-              );
-            infunc(options.fieldConfig.defaults),
+            std.foldl(
+              function(acc, p)
+                acc
+                + overrides.withPropertiesMixin([
+                  overrides.properties.withId(p)
+                  + overrides.properties.withValue(options[p]),
+                ]),
+              std.objectFields(options),
+              {}
+            ),
         }
         for matcher in matchers
       },

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -204,16 +204,22 @@ function(name, panel)
             ]
           ),
           withPropertiesFromOptions(options):
-            std.foldl(
-              function(acc, p)
-                acc
-                + overrides.withPropertiesMixin([
-                  overrides.properties.withId(p)
-                  + overrides.properties.withValue(options[p]),
-                ]),
-              std.objectFields(options),
-              {}
-            ),
+            local infunc(input, path=[]) =
+              std.foldl(
+                function(acc, p)
+                  acc + (
+                    if p == 'custom'
+                    then infunc(input[p], path=path + [p])
+                    else
+                      overrides.withPropertiesMixin([
+                        overrides.properties.withId(std.join('.', path + [p]))
+                        + overrides.properties.withValue(input[p]),
+                      ])
+                  ),
+                std.objectFields(input),
+                {}
+              );
+            infunc(options.fieldConfig.defaults),
         }
         for matcher in matchers
       },


### PR DESCRIPTION
fixes #99

~I can recall that recursing was needed but I can't seem to find it back, the GUI doesn't
show that behavior either so removing the recursion. This should fix the issue described
in #99. If recursing is needed in only a few cases, I bet a new issue will be raised if
someone runs into it.~