### PR TITLE
fix: set pluginVersion for panels

### DIFF
--- a/grafonnet-base/main.libsonnet
+++ b/grafonnet-base/main.libsonnet
@@ -43,10 +43,21 @@ local veneer = import './veneer/main.libsonnet';
     }),
 
   new(schemas, version):
-    local dashboardSchema = std.filter(
-      function(schema) schema.info.title == 'dashboard',
-      schemas
-    )[0];
+    local dashboardSchema =
+      std.filter(
+        function(schema) schema.info.title == 'dashboard',
+        schemas
+      )[0]
+      + {
+        components+: { schemas+: { Panel+: { properties+: {
+          pluginVersion: {
+            // HACK: Grafana users the pluginVersion to decide which migrations to execute
+            // however the pluginVersion is currently not part of the plugin schema's.
+            // This hack ensures that the pluginVersion matches the Grafana version.
+            const: version,
+          },
+        } } } },
+      };
 
     local allSchemaTitles = std.map(function(x) x.info.title, schemas);
 

--- a/grafonnet-base/main.libsonnet
+++ b/grafonnet-base/main.libsonnet
@@ -51,7 +51,7 @@ local veneer = import './veneer/main.libsonnet';
       + {
         components+: { schemas+: { Panel+: { properties+: {
           pluginVersion: {
-            // HACK: Grafana users the pluginVersion to decide which migrations to execute
+            // HACK: Grafana uses the pluginVersion to decide which migrations to execute
             // however the pluginVersion is currently not part of the plugin schema's.
             // This hack ensures that the pluginVersion matches the Grafana version.
             const: version,

--- a/grafonnet-base/veneer/panel.libsonnet
+++ b/grafonnet-base/veneer/panel.libsonnet
@@ -130,6 +130,7 @@ function(name, panel)
     new(title):
       self.withTitle(title)
       + self.withType()
+      + self.withPluginVersion()
       // Default to Mixed datasource so panels can be datasource agnostic, this
       // requires query targets to explicitly set datasource, which is a lot more
       // interesting from a reusability standpoint.


### PR DESCRIPTION
When the pluginVersion is not set, Grafana may execute certain migrations for the panel,
this may cause unintended changes. Also added a comment in the code to describe this hack,
ideally this information comes from the schema.