### PR TITLE
Support startY in makegrid to run function more than once.

### DIFF
--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -83,7 +83,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     // Loop over rowGroups
     std.foldl(
       function(acc, rowGroup) acc {
-        local y = acc.nexty + startY,
+        local y = acc.nexty,
         nexty: y  // previous y
                + (rowGroup.rows * panelHeight)  // height of all rows
                + rowGroup.rows  // plus 1 for each row
@@ -126,12 +126,12 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
           then panels[0:rowIndexes[0]]
           else panels,  // matches all panels if no Row panels found
         local rows = root.countRows(panelsBeforeRowGroups, panelWidth),
-        nexty: (rows * panelHeight) + rows,
+        nexty: startY + (rows * panelHeight) + rows,
 
         lastRowPanelHeight: 0,  // starts without a row panel
 
         // Create a grid for the panels that come before the rowGroups
-        panels: root.makePanelGrid(panelsBeforeRowGroups, panelWidth, panelHeight, 0),
+        panels: root.makePanelGrid(panelsBeforeRowGroups, panelWidth, panelHeight, startY),
       }
     ).panels,
 }

--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -40,14 +40,17 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       This function will use the full grid of 24 columns, setting `panelWidth` to a value
       that can divide 24 into equal parts will fill up the page nicely. (1, 2, 3, 4, 6, 8, 12)
       Other value for `panelWidth` will leave a gap on the far right.
+
+      Optional `startY` can be provided to place generated grid above or below existing panels.
     |||,
     args=[
       d.arg('panels', d.T.array),
       d.arg('panelWidth', d.T.number),
       d.arg('panelHeight', d.T.number),
+      d.arg('startY', d.T.number),
     ],
   ),
-  makeGrid(panels, panelWidth=8, panelHeight=8):
+  makeGrid(panels, panelWidth=8, panelHeight=8, startY=0):
     // Get indexes for all Row panels
     local rowIndexes = [
       i
@@ -80,7 +83,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     // Loop over rowGroups
     std.foldl(
       function(acc, rowGroup) acc {
-        local y = acc.nexty,
+        local y = acc.nexty + startY,
         nexty: y  // previous y
                + (rowGroup.rows * panelHeight)  // height of all rows
                + rowGroup.rows  // plus 1 for each row


### PR DESCRIPTION
This small addition allows to run makeGrid more than once or combine generated grid with panels generated some other way.

```
            + g.dashboard.withPanels(
                    g.util.grid.makeGrid(
                    [
                        g.panel.row.new("CPU")
                            + g.panel.row.withPanels([
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                            ]),
                    ],
                    6, 2)
                    +
                    g.util.grid.makeGrid(
                    [
                        g.panel.row.new("CPU")
                            + g.panel.row.withPanels([
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                            ]),
                        g.panel.row.new("CPU100")
                            + g.panel.row.withPanels([
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                                g.panel.stat.new("test"),
                            ]),
                    ],
                    8, 6, startY=100),
            )
```

Produces:
![image](https://github.com/grafana/grafonnet/assets/14870891/d194a9cf-3fae-4b6a-89a1-36421c464784)
