### PR TITLE
Add utils.grid.wrapPanels function

### DIFF
--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -149,7 +149,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       function(acc, panel)
         if panel.type == 'row'
         then
-          // when type=row, start new row immediatly and shift Y of new row by by max height recorded
+          // when type=row, start new row immediatly and shift Y of new row by max height recorded
           acc {
             panels+: [
               panel {

--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -131,4 +131,69 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
         panels: root.makePanelGrid(panelsBeforeRowGroups, panelWidth, panelHeight, 0),
       }
     ).panels,
+
+  '#wrapPanels':: d.func.new(
+    |||
+      `wrapPanels` returns an array of `panels` organized in a grid, wrapping up to next 'row' if total width exceeds full grid of 24 columns.
+      'panelHeight' and 'panelWidth' are used unless panels already have height and width defined.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+      d.arg('panelWidth', d.T.number),
+      d.arg('panelHeight', d.T.number),
+      d.arg('startY', d.T.number),
+    ],
+  ),
+  wrapPanels(panels, panelWidth=8, panelHeight=8, startY=0):
+    std.foldl(
+      function(acc, panel)
+        local width = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'w') then panel.gridPos.w else panelWidth;
+        local height = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'h') then panel.gridPos.h else panelHeight;
+        if acc.cursor.x + width > gridWidth
+        then
+          acc {
+            panels+: [
+              panel {
+                gridPos+:
+                  {
+                    x: 0,
+                    y: acc.cursor.y + height,
+                    w: width,
+                    h: height,
+                  },
+              },
+            ],
+            cursor+: {
+              x: 0,
+              y: acc.cursor.y + height,
+            },
+          }
+        else
+          acc {
+            panels+: [
+              panel {
+                gridPos+:
+                  {
+                    x: acc.cursor.x,
+                    y: acc.cursor.y,
+                    w: width,
+                    h: height,
+                  },
+              },
+            ],
+            cursor+: {
+              x: acc.cursor.x + width,
+              y: acc.cursor.y,
+            },
+          },
+      panels,
+      // Initial value for acc
+      {
+        panels: [],
+        cursor: {
+          x: 0,
+          y: startY,
+        },
+      }
+    ).panels,
 }

--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -147,8 +147,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   wrapPanels(panels, panelWidth=8, panelHeight=8, startY=0):
     std.foldl(
       function(acc, panel)
-        local width = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'w') then panel.gridPos.w else panelWidth;
-        local height = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'h') then panel.gridPos.h else panelHeight;
+        local width = std.get(panel.gridPos, 'w', default=panelWidth);
+        local height = std.get(panel.gridPos, 'h', default=panelHeight);
         if acc.cursor.x + width > gridWidth
         then
           acc {
@@ -181,7 +181,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
                   },
               },
             ],
-            cursor+: {
+            cursor+:: {
               x: acc.cursor.x + width,
               y: acc.cursor.y,
             },
@@ -190,7 +190,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
       // Initial value for acc
       {
         panels: [],
-        cursor: {
+        cursor:: {
           x: 0,
           y: startY,
         },

--- a/grafonnet-base/util/grid.libsonnet
+++ b/grafonnet-base/util/grid.libsonnet
@@ -147,8 +147,8 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
   wrapPanels(panels, panelWidth=8, panelHeight=8, startY=0):
     std.foldl(
       function(acc, panel)
-        local width = std.get(panel.gridPos, 'w', default=panelWidth);
-        local height = std.get(panel.gridPos, 'h', default=panelHeight);
+        local width = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'w') then panel.gridPos.w else panelWidth;
+        local height = if std.objectHas(panel,'gridPos') && std.objectHas(panel.gridPos, 'h') then panel.gridPos.h else panelHeight;
         if acc.cursor.x + width > gridWidth
         then
           acc {


### PR DESCRIPTION
This util function can be used to position an array of panels to the grid, without providing `gridPos.x`,`gridPos.y` coordinates. 
Once the total width of panels reaches total length of 24, it wraps to next 'row'.

This can serve as an alternative to `makeGrid`, especially if you want to use various width for panels.

This function uses `gridPos.h` and `gridPos.w` defined in panels by default, and if it is missing, would use panelWidth, panelHeight default values. `x` and `y` are calculated.

Example1:
```
            + g.dashboard.withPanels(
                g.util.grid.wrapPanels(
                    [
                        g.panel.stat.new("test1")
                        + g.panel.stat.gridPos.withH(3),
                        g.panel.stat.new("test2") {gridPos:{w:6, h:3}},
                        g.panel.stat.new("test3")
                        + g.panel.stat.gridPos.withH(3),
                        g.panel.stat.new("test4")
                        + g.panel.stat.gridPos.withW(20)
                        + g.panel.stat.gridPos.withH(3),
                        g.panel.stat.new("test5")
                        + g.panel.stat.gridPos.withW(6)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.stat.new("test6")
                        + g.panel.stat.gridPos.withW(10)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.stat.new("test7")
                        + g.panel.stat.gridPos.withW(2)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.stat.new("test8")
                        + g.panel.stat.gridPos.withW(20)
                        + g.panel.stat.gridPos.withH(6),
                    ], panelWidth=8, panelHeight=8)
            )
```
<img width="1423" alt="image" src="https://github.com/grafana/grafonnet/assets/14870891/8e59d3b6-3b89-4e65-9066-bfcd1cc585d4">


Example2:

```
            + g.dashboard.withPanels(
                g.util.grid.wrapPanels(
                    [
                        g.panel.row.new("Overview"),
                        g.panel.stat.new("test1"),
                        g.panel.stat.new("test2"),
                        g.panel.stat.new("test3"),
                        g.panel.stat.new("test4"),
                        g.panel.stat.new("test5"),
                        g.panel.stat.new("test6"),
                        g.panel.stat.new("test7"),
                        g.panel.stat.new("test8"),
                        g.panel.row.new("CPU"),
                        g.panel.timeSeries.new("test9")
                        + g.panel.stat.gridPos.withW(6)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.timeSeries.new("test10")
                        + g.panel.stat.gridPos.withW(12)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.timeSeries.new("test11")
                        + g.panel.stat.gridPos.withW(6)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.row.new("Memory"),
                        g.panel.timeSeries.new("test12")
                        + g.panel.stat.gridPos.withW(6)
                        + g.panel.stat.gridPos.withH(6),
                        g.panel.timeSeries.new("test13")
                        + g.panel.stat.gridPos.withW(18)
                        + g.panel.stat.gridPos.withH(6),
                    ],panelWidth=6, panelHeight=2)
            )
```
Would generate grid identical to one used in linux overview dashboard:
<img width="1431" alt="image" src="https://github.com/grafana/grafonnet/assets/14870891/eacc23d1-0fb0-452a-88b5-75e42b074e22">
<img width="1416" alt="image" src="https://github.com/grafana/grafonnet/assets/14870891/97e9c21e-488f-4fff-873a-efc4596bec49">


