### PR TITLE
chore: render docs with correct default boolean value

### DIFF
--- a/docs/API/dashboard/annotation.md
+++ b/docs/API/dashboard/annotation.md
@@ -9,7 +9,7 @@
 * [`fn withEnable(value=true)`](#fn-withenable)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
-* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withIconColor(value)`](#fn-withiconcolor)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withTarget(value)`](#fn-withtarget)
@@ -19,12 +19,12 @@
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj filter`](#obj-filter)
-  * [`fn withExclude(value=false)`](#fn-filterwithexclude)
+  * [`fn withExclude(value=true)`](#fn-filterwithexclude)
   * [`fn withIds(value)`](#fn-filterwithids)
   * [`fn withIdsMixin(value)`](#fn-filterwithidsmixin)
 * [`obj target`](#obj-target)
   * [`fn withLimit(value)`](#fn-targetwithlimit)
-  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withMatchAny(value=true)`](#fn-targetwithmatchany)
   * [`fn withTags(value)`](#fn-targetwithtags)
   * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
   * [`fn withType(value)`](#fn-targetwithtype)
@@ -74,7 +74,7 @@ withFilterMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value=false)
+withHide(value=true)
 ```
 
 Annotation queries can be toggled on or off at the top of the dashboard.
@@ -147,7 +147,7 @@ withUid(value)
 #### fn filter.withExclude
 
 ```ts
-withExclude(value=false)
+withExclude(value=true)
 ```
 
 Should the specified panels be included or excluded
@@ -183,7 +183,7 @@ but code+tests is already depending on it so hard to change
 #### fn target.withMatchAny
 
 ```ts
-withMatchAny(value)
+withMatchAny(value=true)
 ```
 
 Only required/valid for the grafana datasource...

--- a/docs/API/dashboard/index.md
+++ b/docs/API/dashboard/index.md
@@ -18,7 +18,7 @@ grafonnet.dashboard
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
-* [`fn withLiveNow(value)`](#fn-withlivenow)
+* [`fn withLiveNow(value=true)`](#fn-withlivenow)
 * [`fn withPanels(value)`](#fn-withpanels)
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
@@ -42,9 +42,9 @@ grafonnet.dashboard
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
 * [`obj timepicker`](#obj-timepicker)
-  * [`fn withCollapse(value=false)`](#fn-timepickerwithcollapse)
+  * [`fn withCollapse(value=true)`](#fn-timepickerwithcollapse)
   * [`fn withEnable(value=true)`](#fn-timepickerwithenable)
-  * [`fn withHidden(value=false)`](#fn-timepickerwithhidden)
+  * [`fn withHidden(value=true)`](#fn-timepickerwithhidden)
   * [`fn withRefreshIntervals(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervals)
   * [`fn withRefreshIntervalsMixin(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervalsmixin)
   * [`fn withTimeOptions(value=["5m","15m","1h","6h","12h","24h","2d","7d","30d"])`](#fn-timepickerwithtimeoptions)
@@ -159,7 +159,7 @@ g.dashboard.new('Title dashboard')
 ### fn withLiveNow
 
 ```ts
-withLiveNow(value)
+withLiveNow(value=true)
 ```
 
 When set to true, the dashboard will redraw panels at an interval matching the pixel width.
@@ -346,7 +346,7 @@ withTo(value="now")
 #### fn timepicker.withCollapse
 
 ```ts
-withCollapse(value=false)
+withCollapse(value=true)
 ```
 
 Whether timepicker is collapsed or not.
@@ -362,7 +362,7 @@ Whether timepicker is enabled or not.
 #### fn timepicker.withHidden
 
 ```ts
-withHidden(value=false)
+withHidden(value=true)
 ```
 
 Whether timepicker is visible or not.

--- a/docs/API/dashboard/link.md
+++ b/docs/API/dashboard/link.md
@@ -22,19 +22,19 @@ g.dashboard.new('Title dashboard')
 * [`obj dashboards`](#obj-dashboards)
   * [`fn new(title, tags)`](#fn-dashboardsnew)
   * [`obj options`](#obj-dashboardsoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-dashboardsoptionswithtargetblank)
 * [`obj link`](#obj-link)
   * [`fn new(title, url)`](#fn-linknew)
   * [`fn withIcon(value)`](#fn-linkwithicon)
   * [`fn withTooltip(value)`](#fn-linkwithtooltip)
   * [`obj options`](#obj-linkoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-linkoptionswithtargetblank)
 
 ## Fields
 
@@ -56,7 +56,7 @@ Create links to dashboards based on `tags`.
 ##### fn dashboards.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -64,7 +64,7 @@ withAsDropdown(value=false)
 ##### fn dashboards.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -72,7 +72,7 @@ withIncludeVars(value=false)
 ##### fn dashboards.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -80,7 +80,7 @@ withKeepTime(value=false)
 ##### fn dashboards.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 
@@ -119,7 +119,7 @@ withTooltip(value)
 ##### fn link.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -127,7 +127,7 @@ withAsDropdown(value=false)
 ##### fn link.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -135,7 +135,7 @@ withIncludeVars(value=false)
 ##### fn link.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -143,7 +143,7 @@ withKeepTime(value=false)
 ##### fn link.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/dashboard/variable.md
+++ b/docs/API/dashboard/variable.md
@@ -113,7 +113,7 @@ g.dashboard.new('my dashboard')
       * [`fn withNothing()`](#fn-querygeneraloptionsshowondashboardwithnothing)
       * [`fn withValueOnly()`](#fn-querygeneraloptionsshowondashboardwithvalueonly)
   * [`obj queryTypes`](#obj-queryquerytypes)
-    * [`fn withLabelValues(label, metric)`](#fn-queryquerytypeswithlabelvalues)
+    * [`fn withLabelValues(label, metric="")`](#fn-queryquerytypeswithlabelvalues)
   * [`obj refresh`](#obj-queryrefresh)
     * [`fn onLoad()`](#fn-queryrefreshonload)
     * [`fn onTime()`](#fn-queryrefreshontime)
@@ -668,7 +668,7 @@ withValueOnly()
 ##### fn query.queryTypes.withLabelValues
 
 ```ts
-withLabelValues(label, metric)
+withLabelValues(label, metric="")
 ```
 
 Construct a Prometheus template variable using `label_values()`.

--- a/docs/API/panel/alertGroups/index.md
+++ b/docs/API/panel/alertGroups/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,7 +27,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withAlertmanager(value)`](#fn-optionswithalertmanager)
-  * [`fn withExpandAll(value)`](#fn-optionswithexpandall)
+  * [`fn withExpandAll(value=true)`](#fn-optionswithexpandall)
   * [`fn withLabels(value)`](#fn-optionswithlabels)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -36,7 +36,7 @@ grafonnet.panel.alertGroups
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -113,7 +113,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -175,7 +175,7 @@ Name of the alertmanager used as a source for alerts
 #### fn options.withExpandAll
 
 ```ts
-withExpandAll(value)
+withExpandAll(value=true)
 ```
 
 Expand all alert groups by default
@@ -248,7 +248,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/alertGroups/link.md
+++ b/docs/API/panel/alertGroups/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/alertGroups/transformation.md
+++ b/docs/API/panel/alertGroups/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/annotationsList/index.md
+++ b/docs/API/panel/annotationsList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.annotationsList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,8 +30,8 @@ grafonnet.panel.annotationsList
   * [`fn withNavigateAfter(value="10m")`](#fn-optionswithnavigateafter)
   * [`fn withNavigateBefore(value="10m")`](#fn-optionswithnavigatebefore)
   * [`fn withNavigateToPanel(value=true)`](#fn-optionswithnavigatetopanel)
-  * [`fn withOnlyFromThisDashboard(value=false)`](#fn-optionswithonlyfromthisdashboard)
-  * [`fn withOnlyInTimeRange(value=false)`](#fn-optionswithonlyintimerange)
+  * [`fn withOnlyFromThisDashboard(value=true)`](#fn-optionswithonlyfromthisdashboard)
+  * [`fn withOnlyInTimeRange(value=true)`](#fn-optionswithonlyintimerange)
   * [`fn withShowTags(value=true)`](#fn-optionswithshowtags)
   * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withShowUser(value=true)`](#fn-optionswithshowuser)
@@ -44,7 +44,7 @@ grafonnet.panel.annotationsList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -207,7 +207,7 @@ withNavigateToPanel(value=true)
 #### fn options.withOnlyFromThisDashboard
 
 ```ts
-withOnlyFromThisDashboard(value=false)
+withOnlyFromThisDashboard(value=true)
 ```
 
 
@@ -215,7 +215,7 @@ withOnlyFromThisDashboard(value=false)
 #### fn options.withOnlyInTimeRange
 
 ```ts
-withOnlyInTimeRange(value=false)
+withOnlyInTimeRange(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/annotationsList/link.md
+++ b/docs/API/panel/annotationsList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/annotationsList/transformation.md
+++ b/docs/API/panel/annotationsList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/barChart/index.md
+++ b/docs/API/panel/barChart/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.barChart
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -37,9 +37,9 @@ grafonnet.panel.barChart
       * [`fn withThresholdsStyle(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstyle)
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
@@ -48,7 +48,7 @@ grafonnet.panel.barChart
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -59,7 +59,7 @@ grafonnet.panel.barChart
   * [`fn withBarRadius(value=0)`](#fn-optionswithbarradius)
   * [`fn withBarWidth(value=0.97)`](#fn-optionswithbarwidth)
   * [`fn withColorByField(value)`](#fn-optionswithcolorbyfield)
-  * [`fn withFullHighlight(value=false)`](#fn-optionswithfullhighlight)
+  * [`fn withFullHighlight(value=true)`](#fn-optionswithfullhighlight)
   * [`fn withGroupWidth(value=0.7)`](#fn-optionswithgroupwidth)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
@@ -75,15 +75,15 @@ grafonnet.panel.barChart
   * [`fn withXTickLabelRotation(value=0)`](#fn-optionswithxticklabelrotation)
   * [`fn withXTickLabelSpacing(value=0)`](#fn-optionswithxticklabelspacing)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
@@ -98,7 +98,7 @@ grafonnet.panel.barChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -317,7 +317,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -325,7 +325,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -333,7 +333,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -394,7 +394,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -472,7 +472,7 @@ Use the color value for a sibling field to color each bar value.
 #### fn options.withFullHighlight
 
 ```ts
-withFullHighlight(value=false)
+withFullHighlight(value=true)
 ```
 
 Enables mode which highlights the entire bar area and shows tooltip when cursor
@@ -597,7 +597,7 @@ negative values indicate backwards skipping behavior
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -632,7 +632,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -650,7 +650,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -666,7 +666,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/barChart/link.md
+++ b/docs/API/panel/barChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/barChart/transformation.md
+++ b/docs/API/panel/barChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/barGauge/index.md
+++ b/docs/API/panel/barGauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.barGauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.barGauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -52,7 +52,7 @@ grafonnet.panel.barGauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -129,7 +129,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -305,7 +305,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -389,7 +389,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/barGauge/link.md
+++ b/docs/API/panel/barGauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/barGauge/transformation.md
+++ b/docs/API/panel/barGauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/candlestick/index.md
+++ b/docs/API/panel/candlestick/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.candlestick
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.candlestick
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/candlestick/link.md
+++ b/docs/API/panel/candlestick/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/candlestick/transformation.md
+++ b/docs/API/panel/candlestick/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/canvas/index.md
+++ b/docs/API/panel/canvas/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.canvas
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.canvas
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/canvas/link.md
+++ b/docs/API/panel/canvas/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/canvas/transformation.md
+++ b/docs/API/panel/canvas/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/dashboardList/index.md
+++ b/docs/API/panel/dashboardList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withFolderId(value)`](#fn-optionswithfolderid)
-  * [`fn withIncludeVars(value=false)`](#fn-optionswithincludevars)
-  * [`fn withKeepTime(value=false)`](#fn-optionswithkeeptime)
+  * [`fn withIncludeVars(value=true)`](#fn-optionswithincludevars)
+  * [`fn withKeepTime(value=true)`](#fn-optionswithkeeptime)
   * [`fn withMaxItems(value=10)`](#fn-optionswithmaxitems)
   * [`fn withQuery(value="")`](#fn-optionswithquery)
   * [`fn withShowHeadings(value=true)`](#fn-optionswithshowheadings)
-  * [`fn withShowRecentlyViewed(value=false)`](#fn-optionswithshowrecentlyviewed)
-  * [`fn withShowSearch(value=false)`](#fn-optionswithshowsearch)
+  * [`fn withShowRecentlyViewed(value=true)`](#fn-optionswithshowrecentlyviewed)
+  * [`fn withShowSearch(value=true)`](#fn-optionswithshowsearch)
   * [`fn withShowStarred(value=true)`](#fn-optionswithshowstarred)
   * [`fn withTags(value)`](#fn-optionswithtags)
   * [`fn withTagsMixin(value)`](#fn-optionswithtagsmixin)
@@ -44,7 +44,7 @@ grafonnet.panel.dashboardList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -183,7 +183,7 @@ withFolderId(value)
 #### fn options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ withIncludeVars(value=false)
 #### fn options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -223,7 +223,7 @@ withShowHeadings(value=true)
 #### fn options.withShowRecentlyViewed
 
 ```ts
-withShowRecentlyViewed(value=false)
+withShowRecentlyViewed(value=true)
 ```
 
 
@@ -231,7 +231,7 @@ withShowRecentlyViewed(value=false)
 #### fn options.withShowSearch
 
 ```ts
-withShowSearch(value=false)
+withShowSearch(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/dashboardList/link.md
+++ b/docs/API/panel/dashboardList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/dashboardList/transformation.md
+++ b/docs/API/panel/dashboardList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/datagrid/index.md
+++ b/docs/API/panel/datagrid/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.datagrid
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -34,7 +34,7 @@ grafonnet.panel.datagrid
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -111,7 +111,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -230,7 +230,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/datagrid/link.md
+++ b/docs/API/panel/datagrid/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/datagrid/transformation.md
+++ b/docs/API/panel/datagrid/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/debug/index.md
+++ b/docs/API/panel/debug/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.debug
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,9 +30,9 @@ grafonnet.panel.debug
   * [`fn withCountersMixin(value)`](#fn-optionswithcountersmixin)
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj counters`](#obj-optionscounters)
-    * [`fn withDataChanged(value)`](#fn-optionscounterswithdatachanged)
-    * [`fn withRender(value)`](#fn-optionscounterswithrender)
-    * [`fn withSchemaChanged(value)`](#fn-optionscounterswithschemachanged)
+    * [`fn withDataChanged(value=true)`](#fn-optionscounterswithdatachanged)
+    * [`fn withRender(value=true)`](#fn-optionscounterswithrender)
+    * [`fn withSchemaChanged(value=true)`](#fn-optionscounterswithschemachanged)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -40,7 +40,7 @@ grafonnet.panel.debug
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -117,7 +117,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -200,7 +200,7 @@ Accepted values for `value` are "render", "events", "cursor", "State", "ThrowErr
 ##### fn options.counters.withDataChanged
 
 ```ts
-withDataChanged(value)
+withDataChanged(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ withDataChanged(value)
 ##### fn options.counters.withRender
 
 ```ts
-withRender(value)
+withRender(value=true)
 ```
 
 
@@ -216,7 +216,7 @@ withRender(value)
 ##### fn options.counters.withSchemaChanged
 
 ```ts
-withSchemaChanged(value)
+withSchemaChanged(value=true)
 ```
 
 
@@ -281,7 +281,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/debug/link.md
+++ b/docs/API/panel/debug/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/debug/transformation.md
+++ b/docs/API/panel/debug/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/gauge/index.md
+++ b/docs/API/panel/gauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.gauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -29,7 +29,7 @@ grafonnet.panel.gauge
   * [`fn withOrientation(value)`](#fn-optionswithorientation)
   * [`fn withReduceOptions(value)`](#fn-optionswithreduceoptions)
   * [`fn withReduceOptionsMixin(value)`](#fn-optionswithreduceoptionsmixin)
-  * [`fn withShowThresholdLabels(value=false)`](#fn-optionswithshowthresholdlabels)
+  * [`fn withShowThresholdLabels(value=true)`](#fn-optionswithshowthresholdlabels)
   * [`fn withShowThresholdMarkers(value=true)`](#fn-optionswithshowthresholdmarkers)
   * [`fn withText(value)`](#fn-optionswithtext)
   * [`fn withTextMixin(value)`](#fn-optionswithtextmixin)
@@ -38,7 +38,7 @@ grafonnet.panel.gauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -49,7 +49,7 @@ grafonnet.panel.gauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -126,7 +126,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -206,7 +206,7 @@ TODO docs
 #### fn options.withShowThresholdLabels
 
 ```ts
-withShowThresholdLabels(value=false)
+withShowThresholdLabels(value=true)
 ```
 
 
@@ -273,7 +273,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -357,7 +357,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/gauge/link.md
+++ b/docs/API/panel/gauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/gauge/transformation.md
+++ b/docs/API/panel/gauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/geomap/index.md
+++ b/docs/API/panel/geomap/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.geomap
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -43,7 +43,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionsbasemapwithlocationmixin)
     * [`fn withName(value)`](#fn-optionsbasemapwithname)
     * [`fn withOpacity(value)`](#fn-optionsbasemapwithopacity)
-    * [`fn withTooltip(value)`](#fn-optionsbasemapwithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionsbasemapwithtooltip)
     * [`fn withType(value)`](#fn-optionsbasemapwithtype)
     * [`obj location`](#obj-optionsbasemaplocation)
       * [`fn withGazetteer(value)`](#fn-optionsbasemaplocationwithgazetteer)
@@ -54,12 +54,12 @@ grafonnet.panel.geomap
       * [`fn withMode(value)`](#fn-optionsbasemaplocationwithmode)
       * [`fn withWkt(value)`](#fn-optionsbasemaplocationwithwkt)
   * [`obj controls`](#obj-optionscontrols)
-    * [`fn withMouseWheelZoom(value)`](#fn-optionscontrolswithmousewheelzoom)
-    * [`fn withShowAttribution(value)`](#fn-optionscontrolswithshowattribution)
-    * [`fn withShowDebug(value)`](#fn-optionscontrolswithshowdebug)
-    * [`fn withShowMeasure(value)`](#fn-optionscontrolswithshowmeasure)
-    * [`fn withShowScale(value)`](#fn-optionscontrolswithshowscale)
-    * [`fn withShowZoom(value)`](#fn-optionscontrolswithshowzoom)
+    * [`fn withMouseWheelZoom(value=true)`](#fn-optionscontrolswithmousewheelzoom)
+    * [`fn withShowAttribution(value=true)`](#fn-optionscontrolswithshowattribution)
+    * [`fn withShowDebug(value=true)`](#fn-optionscontrolswithshowdebug)
+    * [`fn withShowMeasure(value=true)`](#fn-optionscontrolswithshowmeasure)
+    * [`fn withShowScale(value=true)`](#fn-optionscontrolswithshowscale)
+    * [`fn withShowZoom(value=true)`](#fn-optionscontrolswithshowzoom)
   * [`obj layers`](#obj-optionslayers)
     * [`fn withConfig(value)`](#fn-optionslayerswithconfig)
     * [`fn withFilterData(value)`](#fn-optionslayerswithfilterdata)
@@ -67,7 +67,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionslayerswithlocationmixin)
     * [`fn withName(value)`](#fn-optionslayerswithname)
     * [`fn withOpacity(value)`](#fn-optionslayerswithopacity)
-    * [`fn withTooltip(value)`](#fn-optionslayerswithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionslayerswithtooltip)
     * [`fn withType(value)`](#fn-optionslayerswithtype)
     * [`obj location`](#obj-optionslayerslocation)
       * [`fn withGazetteer(value)`](#fn-optionslayerslocationwithgazetteer)
@@ -82,14 +82,14 @@ grafonnet.panel.geomap
   * [`obj view`](#obj-optionsview)
     * [`fn withAllLayers(value=true)`](#fn-optionsviewwithalllayers)
     * [`fn withId(value="zero")`](#fn-optionsviewwithid)
-    * [`fn withLastOnly(value)`](#fn-optionsviewwithlastonly)
+    * [`fn withLastOnly(value=true)`](#fn-optionsviewwithlastonly)
     * [`fn withLat(value=0)`](#fn-optionsviewwithlat)
     * [`fn withLayer(value)`](#fn-optionsviewwithlayer)
     * [`fn withLon(value=0)`](#fn-optionsviewwithlon)
     * [`fn withMaxZoom(value)`](#fn-optionsviewwithmaxzoom)
     * [`fn withMinZoom(value)`](#fn-optionsviewwithminzoom)
     * [`fn withPadding(value)`](#fn-optionsviewwithpadding)
-    * [`fn withShared(value)`](#fn-optionsviewwithshared)
+    * [`fn withShared(value=true)`](#fn-optionsviewwithshared)
     * [`fn withZoom(value=1)`](#fn-optionsviewwithzoom)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -98,7 +98,7 @@ grafonnet.panel.geomap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -175,7 +175,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -362,7 +362,7 @@ Layer opacity (0-1)
 ##### fn options.basemap.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -442,7 +442,7 @@ withWkt(value)
 ##### fn options.controls.withMouseWheelZoom
 
 ```ts
-withMouseWheelZoom(value)
+withMouseWheelZoom(value=true)
 ```
 
 let the mouse wheel zoom
@@ -450,7 +450,7 @@ let the mouse wheel zoom
 ##### fn options.controls.withShowAttribution
 
 ```ts
-withShowAttribution(value)
+withShowAttribution(value=true)
 ```
 
 Lower right
@@ -458,7 +458,7 @@ Lower right
 ##### fn options.controls.withShowDebug
 
 ```ts
-withShowDebug(value)
+withShowDebug(value=true)
 ```
 
 Show debug
@@ -466,7 +466,7 @@ Show debug
 ##### fn options.controls.withShowMeasure
 
 ```ts
-withShowMeasure(value)
+withShowMeasure(value=true)
 ```
 
 Show measure
@@ -474,7 +474,7 @@ Show measure
 ##### fn options.controls.withShowScale
 
 ```ts
-withShowScale(value)
+withShowScale(value=true)
 ```
 
 Scale options
@@ -482,7 +482,7 @@ Scale options
 ##### fn options.controls.withShowZoom
 
 ```ts
-withShowZoom(value)
+withShowZoom(value=true)
 ```
 
 Zoom (upper left)
@@ -543,7 +543,7 @@ Layer opacity (0-1)
 ##### fn options.layers.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -652,7 +652,7 @@ withId(value="zero")
 ##### fn options.view.withLastOnly
 
 ```ts
-withLastOnly(value)
+withLastOnly(value=true)
 ```
 
 
@@ -708,7 +708,7 @@ withPadding(value)
 ##### fn options.view.withShared
 
 ```ts
-withShared(value)
+withShared(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/geomap/link.md
+++ b/docs/API/panel/geomap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/geomap/transformation.md
+++ b/docs/API/panel/geomap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/heatmap/index.md
+++ b/docs/API/panel/heatmap/index.md
@@ -24,16 +24,16 @@ grafonnet.panel.heatmap
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.heatmap
   * [`fn withName(value)`](#fn-librarypanelwithname)
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
-  * [`fn withCalculate(value=false)`](#fn-optionswithcalculate)
+  * [`fn withCalculate(value=true)`](#fn-optionswithcalculate)
   * [`fn withCalculation(value)`](#fn-optionswithcalculation)
   * [`fn withCalculationMixin(value)`](#fn-optionswithcalculationmixin)
   * [`fn withCellGap(value=1)`](#fn-optionswithcellgap)
@@ -101,7 +101,7 @@ grafonnet.panel.heatmap
       * [`fn withMax(value)`](#fn-optionscolorheatmapcoloroptionswithmax)
       * [`fn withMin(value)`](#fn-optionscolorheatmapcoloroptionswithmin)
       * [`fn withMode(value)`](#fn-optionscolorheatmapcoloroptionswithmode)
-      * [`fn withReverse(value)`](#fn-optionscolorheatmapcoloroptionswithreverse)
+      * [`fn withReverse(value=true)`](#fn-optionscolorheatmapcoloroptionswithreverse)
       * [`fn withScale(value)`](#fn-optionscolorheatmapcoloroptionswithscale)
       * [`fn withScheme(value)`](#fn-optionscolorheatmapcoloroptionswithscheme)
       * [`fn withSteps(value)`](#fn-optionscolorheatmapcoloroptionswithsteps)
@@ -114,17 +114,17 @@ grafonnet.panel.heatmap
       * [`fn withGe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithge)
       * [`fn withLe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithle)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withShow(value)`](#fn-optionslegendwithshow)
+    * [`fn withShow(value=true)`](#fn-optionslegendwithshow)
   * [`obj rowsFrame`](#obj-optionsrowsframe)
     * [`fn withLayout(value)`](#fn-optionsrowsframewithlayout)
     * [`fn withValue(value)`](#fn-optionsrowsframewithvalue)
   * [`obj tooltip`](#obj-optionstooltip)
-    * [`fn withShow(value)`](#fn-optionstooltipwithshow)
-    * [`fn withYHistogram(value)`](#fn-optionstooltipwithyhistogram)
+    * [`fn withShow(value=true)`](#fn-optionstooltipwithshow)
+    * [`fn withYHistogram(value=true)`](#fn-optionstooltipwithyhistogram)
   * [`obj yAxis`](#obj-optionsyaxis)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsyaxiswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsyaxiswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsyaxiswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsyaxiswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsyaxiswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsyaxiswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsyaxiswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsyaxiswithaxissoftmax)
@@ -133,7 +133,7 @@ grafonnet.panel.heatmap
     * [`fn withDecimals(value)`](#fn-optionsyaxiswithdecimals)
     * [`fn withMax(value)`](#fn-optionsyaxiswithmax)
     * [`fn withMin(value)`](#fn-optionsyaxiswithmin)
-    * [`fn withReverse(value)`](#fn-optionsyaxiswithreverse)
+    * [`fn withReverse(value=true)`](#fn-optionsyaxiswithreverse)
     * [`fn withScaleDistribution(value)`](#fn-optionsyaxiswithscaledistribution)
     * [`fn withScaleDistributionMixin(value)`](#fn-optionsyaxiswithscaledistributionmixin)
     * [`fn withUnit(value)`](#fn-optionsyaxiswithunit)
@@ -148,7 +148,7 @@ grafonnet.panel.heatmap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -258,7 +258,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -266,7 +266,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -274,7 +274,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -322,7 +322,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -376,7 +376,7 @@ withUid(value)
 #### fn options.withCalculate
 
 ```ts
-withCalculate(value=false)
+withCalculate(value=true)
 ```
 
 Controls if the heatmap should be calculated from data
@@ -824,7 +824,7 @@ Accepted values for `value` are "opacity", "scheme"
 ###### fn options.color.HeatmapColorOptions.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the color scheme
@@ -910,7 +910,7 @@ Sets the filter range to values less than or equal to the given value
 ##### fn options.legend.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the legend is shown
@@ -942,7 +942,7 @@ Sets the name of the cell when not calculating from data
 ##### fn options.tooltip.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the tooltip is shown
@@ -950,7 +950,7 @@ Controls if the tooltip is shown
 ##### fn options.tooltip.withYHistogram
 
 ```ts
-withYHistogram(value)
+withYHistogram(value=true)
 ```
 
 Controls if the tooltip shows a histogram of the y-axis values
@@ -961,7 +961,7 @@ Controls if the tooltip shows a histogram of the y-axis values
 ##### fn options.yAxis.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -979,7 +979,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.yAxis.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -1053,7 +1053,7 @@ Sets the minimum value for the yAxis
 ##### fn options.yAxis.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the yAxis
@@ -1171,7 +1171,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/heatmap/link.md
+++ b/docs/API/panel/heatmap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/heatmap/transformation.md
+++ b/docs/API/panel/heatmap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/histogram/index.md
+++ b/docs/API/panel/histogram/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.histogram
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -35,16 +35,16 @@ grafonnet.panel.histogram
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -54,21 +54,21 @@ grafonnet.panel.histogram
 * [`obj options`](#obj-options)
   * [`fn withBucketOffset(value=0)`](#fn-optionswithbucketoffset)
   * [`fn withBucketSize(value)`](#fn-optionswithbucketsize)
-  * [`fn withCombine(value)`](#fn-optionswithcombine)
+  * [`fn withCombine(value=true)`](#fn-optionswithcombine)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -80,7 +80,7 @@ grafonnet.panel.histogram
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -155,7 +155,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -173,7 +173,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -283,7 +283,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -291,7 +291,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -299,7 +299,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -347,7 +347,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -417,7 +417,7 @@ Size of each bucket
 #### fn options.withCombine
 
 ```ts
-withCombine(value)
+withCombine(value=true)
 ```
 
 Combines multiple series into a single histogram
@@ -460,7 +460,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -495,7 +495,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -513,7 +513,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -529,7 +529,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -625,7 +625,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/histogram/link.md
+++ b/docs/API/panel/histogram/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/histogram/transformation.md
+++ b/docs/API/panel/histogram/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/logs/index.md
+++ b/docs/API/panel/logs/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withDedupStrategy(value)`](#fn-optionswithdedupstrategy)
-  * [`fn withEnableLogDetails(value)`](#fn-optionswithenablelogdetails)
-  * [`fn withPrettifyLogMessage(value)`](#fn-optionswithprettifylogmessage)
-  * [`fn withShowCommonLabels(value)`](#fn-optionswithshowcommonlabels)
-  * [`fn withShowLabels(value)`](#fn-optionswithshowlabels)
-  * [`fn withShowTime(value)`](#fn-optionswithshowtime)
+  * [`fn withEnableLogDetails(value=true)`](#fn-optionswithenablelogdetails)
+  * [`fn withPrettifyLogMessage(value=true)`](#fn-optionswithprettifylogmessage)
+  * [`fn withShowCommonLabels(value=true)`](#fn-optionswithshowcommonlabels)
+  * [`fn withShowLabels(value=true)`](#fn-optionswithshowlabels)
+  * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withSortOrder(value)`](#fn-optionswithsortorder)
-  * [`fn withWrapLogMessage(value)`](#fn-optionswithwraplogmessage)
+  * [`fn withWrapLogMessage(value=true)`](#fn-optionswithwraplogmessage)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.logs
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -182,7 +182,7 @@ Accepted values for `value` are "none", "exact", "numbers", "signature"
 #### fn options.withEnableLogDetails
 
 ```ts
-withEnableLogDetails(value)
+withEnableLogDetails(value=true)
 ```
 
 
@@ -190,7 +190,7 @@ withEnableLogDetails(value)
 #### fn options.withPrettifyLogMessage
 
 ```ts
-withPrettifyLogMessage(value)
+withPrettifyLogMessage(value=true)
 ```
 
 
@@ -198,7 +198,7 @@ withPrettifyLogMessage(value)
 #### fn options.withShowCommonLabels
 
 ```ts
-withShowCommonLabels(value)
+withShowCommonLabels(value=true)
 ```
 
 
@@ -206,7 +206,7 @@ withShowCommonLabels(value)
 #### fn options.withShowLabels
 
 ```ts
-withShowLabels(value)
+withShowLabels(value=true)
 ```
 
 
@@ -214,7 +214,7 @@ withShowLabels(value)
 #### fn options.withShowTime
 
 ```ts
-withShowTime(value)
+withShowTime(value=true)
 ```
 
 
@@ -232,7 +232,7 @@ Accepted values for `value` are "Descending", "Ascending"
 #### fn options.withWrapLogMessage
 
 ```ts
-withWrapLogMessage(value)
+withWrapLogMessage(value=true)
 ```
 
 
@@ -297,7 +297,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/logs/link.md
+++ b/docs/API/panel/logs/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/logs/transformation.md
+++ b/docs/API/panel/logs/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/news/index.md
+++ b/docs/API/panel/news/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.news
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -35,7 +35,7 @@ grafonnet.panel.news
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -112,7 +112,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -239,7 +239,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/news/link.md
+++ b/docs/API/panel/news/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/news/transformation.md
+++ b/docs/API/panel/news/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/nodeGraph/index.md
+++ b/docs/API/panel/nodeGraph/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.nodeGraph
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,7 +48,7 @@ grafonnet.panel.nodeGraph
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -125,7 +125,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/nodeGraph/link.md
+++ b/docs/API/panel/nodeGraph/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/nodeGraph/transformation.md
+++ b/docs/API/panel/nodeGraph/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/pieChart/index.md
+++ b/docs/API/panel/pieChart/index.md
@@ -22,12 +22,12 @@ grafonnet.panel.pieChart
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.pieChart
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withValues(value)`](#fn-optionslegendwithvalues)
     * [`fn withValuesMixin(value)`](#fn-optionslegendwithvaluesmixin)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
@@ -65,7 +65,7 @@ grafonnet.panel.pieChart
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -79,7 +79,7 @@ grafonnet.panel.pieChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -181,7 +181,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -189,7 +189,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -365,7 +365,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -400,7 +400,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -418,7 +418,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -434,7 +434,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -501,7 +501,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -608,7 +608,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/pieChart/link.md
+++ b/docs/API/panel/pieChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/pieChart/transformation.md
+++ b/docs/API/panel/pieChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/row.md
+++ b/docs/API/panel/row.md
@@ -5,7 +5,7 @@ grafonnet.panel.row
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withCollapsed(value=false)`](#fn-withcollapsed)
+* [`fn withCollapsed(value=true)`](#fn-withcollapsed)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withGridPos(value)`](#fn-withgridpos)
@@ -21,7 +21,7 @@ grafonnet.panel.row
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -39,7 +39,7 @@ Creates a new row panel with a title.
 ### fn withCollapsed
 
 ```ts
-withCollapsed(value=false)
+withCollapsed(value=true)
 ```
 
 
@@ -157,7 +157,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed

--- a/docs/API/panel/stat/index.md
+++ b/docs/API/panel/stat/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.stat
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -40,7 +40,7 @@ grafonnet.panel.stat
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -51,7 +51,7 @@ grafonnet.panel.stat
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -128,7 +128,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -299,7 +299,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -383,7 +383,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/stat/link.md
+++ b/docs/API/panel/stat/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/stat/transformation.md
+++ b/docs/API/panel/stat/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/stateTimeline/index.md
+++ b/docs/API/panel/stateTimeline/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.stateTimeline
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=0)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.stateTimeline
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -68,7 +68,7 @@ grafonnet.panel.stateTimeline
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -178,7 +178,7 @@ withLineWidth(value=0)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -186,7 +186,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -194,7 +194,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -213,7 +213,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -350,7 +350,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -385,7 +385,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -403,7 +403,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -419,7 +419,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -515,7 +515,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/stateTimeline/link.md
+++ b/docs/API/panel/stateTimeline/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/stateTimeline/transformation.md
+++ b/docs/API/panel/stateTimeline/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/statusHistory/index.md
+++ b/docs/API/panel/statusHistory/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.statusHistory
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=1)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -47,15 +47,15 @@ grafonnet.panel.statusHistory
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -67,7 +67,7 @@ grafonnet.panel.statusHistory
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -177,7 +177,7 @@ withLineWidth(value=1)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -185,7 +185,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -193,7 +193,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -212,7 +212,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -376,7 +376,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -394,7 +394,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -410,7 +410,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -506,7 +506,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/statusHistory/link.md
+++ b/docs/API/panel/statusHistory/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/statusHistory/transformation.md
+++ b/docs/API/panel/statusHistory/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/table/index.md
+++ b/docs/API/panel/table/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.table
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,22 +31,22 @@ grafonnet.panel.table
   * [`fn withFooterMixin(value={"countRows": false,"reducer": [],"show": false})`](#fn-optionswithfootermixin)
   * [`fn withFrameIndex(value=0)`](#fn-optionswithframeindex)
   * [`fn withShowHeader(value=true)`](#fn-optionswithshowheader)
-  * [`fn withShowTypeIcons(value=false)`](#fn-optionswithshowtypeicons)
+  * [`fn withShowTypeIcons(value=true)`](#fn-optionswithshowtypeicons)
   * [`fn withSortBy(value)`](#fn-optionswithsortby)
   * [`fn withSortByMixin(value)`](#fn-optionswithsortbymixin)
   * [`obj footer`](#obj-optionsfooter)
     * [`fn withTableFooterOptions(value)`](#fn-optionsfooterwithtablefooteroptions)
     * [`fn withTableFooterOptionsMixin(value)`](#fn-optionsfooterwithtablefooteroptionsmixin)
     * [`obj TableFooterOptions`](#obj-optionsfootertablefooteroptions)
-      * [`fn withCountRows(value)`](#fn-optionsfootertablefooteroptionswithcountrows)
-      * [`fn withEnablePagination(value)`](#fn-optionsfootertablefooteroptionswithenablepagination)
+      * [`fn withCountRows(value=true)`](#fn-optionsfootertablefooteroptionswithcountrows)
+      * [`fn withEnablePagination(value=true)`](#fn-optionsfootertablefooteroptionswithenablepagination)
       * [`fn withFields(value)`](#fn-optionsfootertablefooteroptionswithfields)
       * [`fn withFieldsMixin(value)`](#fn-optionsfootertablefooteroptionswithfieldsmixin)
       * [`fn withReducer(value)`](#fn-optionsfootertablefooteroptionswithreducer)
       * [`fn withReducerMixin(value)`](#fn-optionsfootertablefooteroptionswithreducermixin)
-      * [`fn withShow(value)`](#fn-optionsfootertablefooteroptionswithshow)
+      * [`fn withShow(value=true)`](#fn-optionsfootertablefooteroptionswithshow)
   * [`obj sortBy`](#obj-optionssortby)
-    * [`fn withDesc(value)`](#fn-optionssortbywithdesc)
+    * [`fn withDesc(value=true)`](#fn-optionssortbywithdesc)
     * [`fn withDisplayName(value)`](#fn-optionssortbywithdisplayname)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -55,7 +55,7 @@ grafonnet.panel.table
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -132,7 +132,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -226,7 +226,7 @@ Controls whether the panel should show the header
 #### fn options.withShowTypeIcons
 
 ```ts
-withShowTypeIcons(value=false)
+withShowTypeIcons(value=true)
 ```
 
 Controls whether the header should show icons for the column types
@@ -272,7 +272,7 @@ Footer options
 ###### fn options.footer.TableFooterOptions.withCountRows
 
 ```ts
-withCountRows(value)
+withCountRows(value=true)
 ```
 
 
@@ -280,7 +280,7 @@ withCountRows(value)
 ###### fn options.footer.TableFooterOptions.withEnablePagination
 
 ```ts
-withEnablePagination(value)
+withEnablePagination(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ withReducerMixin(value)
 ###### fn options.footer.TableFooterOptions.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 
@@ -331,7 +331,7 @@ withShow(value)
 ##### fn options.sortBy.withDesc
 
 ```ts
-withDesc(value)
+withDesc(value=true)
 ```
 
 Flag used to indicate descending sort order
@@ -404,7 +404,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/table/link.md
+++ b/docs/API/panel/table/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/table/transformation.md
+++ b/docs/API/panel/table/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/text/index.md
+++ b/docs/API/panel/text/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.text
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,8 +32,8 @@ grafonnet.panel.text
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj code`](#obj-optionscode)
     * [`fn withLanguage(value="plaintext")`](#fn-optionscodewithlanguage)
-    * [`fn withShowLineNumbers(value=false)`](#fn-optionscodewithshowlinenumbers)
-    * [`fn withShowMiniMap(value=false)`](#fn-optionscodewithshowminimap)
+    * [`fn withShowLineNumbers(value=true)`](#fn-optionscodewithshowlinenumbers)
+    * [`fn withShowMiniMap(value=true)`](#fn-optionscodewithshowminimap)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.text
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -219,7 +219,7 @@ Accepted values for `value` are "plaintext", "yaml", "xml", "typescript", "sql",
 ##### fn options.code.withShowLineNumbers
 
 ```ts
-withShowLineNumbers(value=false)
+withShowLineNumbers(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withShowLineNumbers(value=false)
 ##### fn options.code.withShowMiniMap
 
 ```ts
-withShowMiniMap(value=false)
+withShowMiniMap(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/text/link.md
+++ b/docs/API/panel/text/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/text/transformation.md
+++ b/docs/API/panel/text/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/timeSeries/index.md
+++ b/docs/API/panel/timeSeries/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.timeSeries
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.timeSeries
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -89,15 +89,15 @@ grafonnet.panel.timeSeries
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -109,7 +109,7 @@ grafonnet.panel.timeSeries
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -184,7 +184,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -202,7 +202,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -495,7 +495,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -503,7 +503,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -511,7 +511,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -622,7 +622,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -727,7 +727,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -762,7 +762,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -780,7 +780,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -796,7 +796,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -892,7 +892,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/timeSeries/link.md
+++ b/docs/API/panel/timeSeries/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/timeSeries/transformation.md
+++ b/docs/API/panel/timeSeries/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/trend/index.md
+++ b/docs/API/panel/trend/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.trend
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.trend
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.trend
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -88,15 +88,15 @@ grafonnet.panel.trend
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`fn withXField(value)`](#fn-optionswithxfield)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -108,7 +108,7 @@ grafonnet.panel.trend
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -183,7 +183,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -201,7 +201,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -494,7 +494,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -502,7 +502,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -510,7 +510,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -621,7 +621,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -718,7 +718,7 @@ Name of the x field to use (defaults to first number)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -753,7 +753,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -771,7 +771,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -787,7 +787,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -883,7 +883,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/trend/link.md
+++ b/docs/API/panel/trend/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/trend/transformation.md
+++ b/docs/API/panel/trend/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/panel/xyChart/index.md
+++ b/docs/API/panel/xyChart/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.xyChart
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,20 +41,20 @@ grafonnet.panel.xyChart
     * [`fn withFrame(value)`](#fn-optionsdimswithframe)
     * [`fn withX(value)`](#fn-optionsdimswithx)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj series`](#obj-optionsseries)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsserieswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsserieswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsserieswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsserieswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsserieswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsserieswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsserieswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsserieswithaxissoftmax)
@@ -81,9 +81,9 @@ grafonnet.panel.xyChart
     * [`fn withX(value)`](#fn-optionsserieswithx)
     * [`fn withY(value)`](#fn-optionsserieswithy)
     * [`obj hideFrom`](#obj-optionsserieshidefrom)
-      * [`fn withLegend(value)`](#fn-optionsserieshidefromwithlegend)
-      * [`fn withTooltip(value)`](#fn-optionsserieshidefromwithtooltip)
-      * [`fn withViz(value)`](#fn-optionsserieshidefromwithviz)
+      * [`fn withLegend(value=true)`](#fn-optionsserieshidefromwithlegend)
+      * [`fn withTooltip(value=true)`](#fn-optionsserieshidefromwithtooltip)
+      * [`fn withViz(value=true)`](#fn-optionsserieshidefromwithviz)
     * [`obj labelValue`](#obj-optionsserieslabelvalue)
       * [`fn withField(value)`](#fn-optionsserieslabelvaluewithfield)
       * [`fn withFixed(value)`](#fn-optionsserieslabelvaluewithfixed)
@@ -118,7 +118,7 @@ grafonnet.panel.xyChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -195,7 +195,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -361,7 +361,7 @@ withX(value)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -396,7 +396,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -414,7 +414,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -430,7 +430,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -449,7 +449,7 @@ withWidth(value)
 ##### fn options.series.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -467,7 +467,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.series.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -684,7 +684,7 @@ withY(value)
 ###### fn options.series.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -692,7 +692,7 @@ withLegend(value)
 ###### fn options.series.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -700,7 +700,7 @@ withTooltip(value)
 ###### fn options.series.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -958,7 +958,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/docs/API/panel/xyChart/link.md
+++ b/docs/API/panel/xyChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/docs/API/panel/xyChart/transformation.md
+++ b/docs/API/panel/xyChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/docs/API/publicdashboard.md
+++ b/docs/API/publicdashboard.md
@@ -5,10 +5,10 @@ grafonnet.publicdashboard
 ## Index
 
 * [`fn withAccessToken(value)`](#fn-withaccesstoken)
-* [`fn withAnnotationsEnabled(value)`](#fn-withannotationsenabled)
+* [`fn withAnnotationsEnabled(value=true)`](#fn-withannotationsenabled)
 * [`fn withDashboardUid(value)`](#fn-withdashboarduid)
-* [`fn withIsEnabled(value)`](#fn-withisenabled)
-* [`fn withTimeSelectionEnabled(value)`](#fn-withtimeselectionenabled)
+* [`fn withIsEnabled(value=true)`](#fn-withisenabled)
+* [`fn withTimeSelectionEnabled(value=true)`](#fn-withtimeselectionenabled)
 * [`fn withUid(value)`](#fn-withuid)
 
 ## Fields
@@ -24,7 +24,7 @@ Unique public access token
 ### fn withAnnotationsEnabled
 
 ```ts
-withAnnotationsEnabled(value)
+withAnnotationsEnabled(value=true)
 ```
 
 Flag that indicates if annotations are enabled
@@ -40,7 +40,7 @@ Dashboard unique identifier referenced by this public dashboard
 ### fn withIsEnabled
 
 ```ts
-withIsEnabled(value)
+withIsEnabled(value=true)
 ```
 
 Flag that indicates if the public dashboard is enabled
@@ -48,7 +48,7 @@ Flag that indicates if the public dashboard is enabled
 ### fn withTimeSelectionEnabled
 
 ```ts
-withTimeSelectionEnabled(value)
+withTimeSelectionEnabled(value=true)
 ```
 
 Flag that indicates if the time range picker is enabled

--- a/docs/API/query/azureMonitor.md
+++ b/docs/API/query/azureMonitor.md
@@ -15,7 +15,7 @@ grafonnet.query.azureMonitor
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGrafanaTemplateVariableFn(value)`](#fn-withgrafanatemplatevariablefn)
 * [`fn withGrafanaTemplateVariableFnMixin(value)`](#fn-withgrafanatemplatevariablefnmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withNamespace(value)`](#fn-withnamespace)
 * [`fn withQueryType(value)`](#fn-withquerytype)
 * [`fn withRefId(value)`](#fn-withrefid)
@@ -250,7 +250,7 @@ withGrafanaTemplateVariableFnMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/docs/API/query/cloudWatch.md
+++ b/docs/API/query/cloudWatch.md
@@ -11,12 +11,12 @@ grafonnet.query.cloudWatch
   * [`fn withDatasource(value)`](#fn-cloudwatchannotationquerywithdatasource)
   * [`fn withDimensions(value)`](#fn-cloudwatchannotationquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchannotationquerywithdimensionsmixin)
-  * [`fn withHide(value)`](#fn-cloudwatchannotationquerywithhide)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchannotationquerywithmatchexact)
+  * [`fn withHide(value=true)`](#fn-cloudwatchannotationquerywithhide)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchannotationquerywithmatchexact)
   * [`fn withMetricName(value)`](#fn-cloudwatchannotationquerywithmetricname)
   * [`fn withNamespace(value)`](#fn-cloudwatchannotationquerywithnamespace)
   * [`fn withPeriod(value)`](#fn-cloudwatchannotationquerywithperiod)
-  * [`fn withPrefixMatching(value)`](#fn-cloudwatchannotationquerywithprefixmatching)
+  * [`fn withPrefixMatching(value=true)`](#fn-cloudwatchannotationquerywithprefixmatching)
   * [`fn withQueryMode(value)`](#fn-cloudwatchannotationquerywithquerymode)
   * [`fn withQueryType(value)`](#fn-cloudwatchannotationquerywithquerytype)
   * [`fn withRefId(value)`](#fn-cloudwatchannotationquerywithrefid)
@@ -27,7 +27,7 @@ grafonnet.query.cloudWatch
 * [`obj CloudWatchLogsQuery`](#obj-cloudwatchlogsquery)
   * [`fn withDatasource(value)`](#fn-cloudwatchlogsquerywithdatasource)
   * [`fn withExpression(value)`](#fn-cloudwatchlogsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchlogsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchlogsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchlogsquerywithid)
   * [`fn withLogGroupNames(value)`](#fn-cloudwatchlogsquerywithloggroupnames)
   * [`fn withLogGroupNamesMixin(value)`](#fn-cloudwatchlogsquerywithloggroupnamesmixin)
@@ -51,10 +51,10 @@ grafonnet.query.cloudWatch
   * [`fn withDimensions(value)`](#fn-cloudwatchmetricsquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchmetricsquerywithdimensionsmixin)
   * [`fn withExpression(value)`](#fn-cloudwatchmetricsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchmetricsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchmetricsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchmetricsquerywithid)
   * [`fn withLabel(value)`](#fn-cloudwatchmetricsquerywithlabel)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchmetricsquerywithmatchexact)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchmetricsquerywithmatchexact)
   * [`fn withMetricEditorMode(value)`](#fn-cloudwatchmetricsquerywithmetriceditormode)
   * [`fn withMetricName(value)`](#fn-cloudwatchmetricsquerywithmetricname)
   * [`fn withMetricQueryType(value)`](#fn-cloudwatchmetricsquerywithmetricquerytype)
@@ -193,7 +193,7 @@ A name/value pair that is part of the identity of a metric. For example, you can
 #### fn CloudWatchAnnotationQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -203,7 +203,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 #### fn CloudWatchAnnotationQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 Only show metrics that exactly match all defined dimension names.
@@ -235,7 +235,7 @@ The length of time associated with a specific Amazon CloudWatch statistic. Can b
 #### fn CloudWatchAnnotationQuery.withPrefixMatching
 
 ```ts
-withPrefixMatching(value)
+withPrefixMatching(value=true)
 ```
 
 Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
@@ -326,7 +326,7 @@ The CloudWatch Logs Insights query to execute
 #### fn CloudWatchLogsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -519,7 +519,7 @@ Math expression query
 #### fn CloudWatchMetricsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -545,7 +545,7 @@ Change the time series legend names using dynamic labels. See https://docs.aws.a
 #### fn CloudWatchMetricsQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 Only show metrics that exactly match all defined dimension names.

--- a/docs/API/query/elasticsearch.md
+++ b/docs/API/query/elasticsearch.md
@@ -8,7 +8,7 @@ grafonnet.query.elasticsearch
 * [`fn withBucketAggs(value)`](#fn-withbucketaggs)
 * [`fn withBucketAggsMixin(value)`](#fn-withbucketaggsmixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withMetrics(value)`](#fn-withmetrics)
 * [`fn withMetricsMixin(value)`](#fn-withmetricsmixin)
 * [`fn withQuery(value)`](#fn-withquery)
@@ -76,13 +76,13 @@ grafonnet.query.elasticsearch
       * [`fn withSize(value)`](#fn-bucketaggstermssettingswithsize)
 * [`obj metrics`](#obj-metrics)
   * [`obj Count`](#obj-metricscount)
-    * [`fn withHide(value)`](#fn-metricscountwithhide)
+    * [`fn withHide(value=true)`](#fn-metricscountwithhide)
     * [`fn withId(value)`](#fn-metricscountwithid)
     * [`fn withType(value)`](#fn-metricscountwithtype)
   * [`obj MetricAggregationWithSettings`](#obj-metricsmetricaggregationwithsettings)
     * [`obj Average`](#obj-metricsmetricaggregationwithsettingsaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettingsmixin)
@@ -94,7 +94,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsaveragesettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsaveragesettingsscriptwithinline)
     * [`obj BucketScript`](#obj-metricsmetricaggregationwithsettingsbucketscript)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariablesmixin)
@@ -111,7 +111,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricsmetricaggregationwithsettingscumulativesum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithsettings)
@@ -121,7 +121,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricsmetricaggregationwithsettingsderivative)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithsettings)
@@ -131,7 +131,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsderivativesettingswithunit)
     * [`obj ExtendedStats`](#obj-metricsmetricaggregationwithsettingsextendedstats)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithid)
       * [`fn withMeta(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmeta)
       * [`fn withMetaMixin(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmetamixin)
@@ -146,7 +146,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsextendedstatssettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatssettingsscriptwithinline)
     * [`obj Logs`](#obj-metricsmetricaggregationwithsettingslogs)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingslogswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettingsmixin)
@@ -155,7 +155,7 @@ grafonnet.query.elasticsearch
         * [`fn withLimit(value)`](#fn-metricsmetricaggregationwithsettingslogssettingswithlimit)
     * [`obj Max`](#obj-metricsmetricaggregationwithsettingsmax)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettingsmixin)
@@ -168,7 +168,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmaxsettingsscriptwithinline)
     * [`obj Min`](#obj-metricsmetricaggregationwithsettingsmin)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsminwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsminwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettingsmixin)
@@ -181,7 +181,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsminsettingsscriptwithinline)
     * [`obj MovingAverage`](#obj-metricsmetricaggregationwithsettingsmovingaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithsettings)
@@ -189,7 +189,7 @@ grafonnet.query.elasticsearch
       * [`fn withType(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithtype)
     * [`obj MovingFunction`](#obj-metricsmetricaggregationwithsettingsmovingfunction)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithsettings)
@@ -204,7 +204,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionsettingsscriptwithinline)
     * [`obj Percentiles`](#obj-metricsmetricaggregationwithsettingspercentiles)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettingsmixin)
@@ -219,7 +219,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingspercentilessettingsscriptwithinline)
     * [`obj Rate`](#obj-metricsmetricaggregationwithsettingsrate)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsratewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsratewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettingsmixin)
@@ -228,7 +228,7 @@ grafonnet.query.elasticsearch
         * [`fn withMode(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithmode)
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithunit)
     * [`obj RawData`](#obj-metricsmetricaggregationwithsettingsrawdata)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettingsmixin)
@@ -236,7 +236,7 @@ grafonnet.query.elasticsearch
       * [`obj settings`](#obj-metricsmetricaggregationwithsettingsrawdatasettings)
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdatasettingswithsize)
     * [`obj RawDocument`](#obj-metricsmetricaggregationwithsettingsrawdocument)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettingsmixin)
@@ -245,7 +245,7 @@ grafonnet.query.elasticsearch
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentsettingswithsize)
     * [`obj SerialDiff`](#obj-metricsmetricaggregationwithsettingsserialdiff)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithsettings)
@@ -255,7 +255,7 @@ grafonnet.query.elasticsearch
         * [`fn withLag(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffsettingswithlag)
     * [`obj Sum`](#obj-metricsmetricaggregationwithsettingssum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingssumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingssumwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettingsmixin)
@@ -267,7 +267,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingssumsettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingssumsettingsscriptwithinline)
     * [`obj TopMetrics`](#obj-metricsmetricaggregationwithsettingstopmetrics)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettingsmixin)
@@ -279,7 +279,7 @@ grafonnet.query.elasticsearch
         * [`fn withOrderBy(value)`](#fn-metricsmetricaggregationwithsettingstopmetricssettingswithorderby)
     * [`obj UniqueCount`](#obj-metricsmetricaggregationwithsettingsuniquecount)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettingsmixin)
@@ -289,7 +289,7 @@ grafonnet.query.elasticsearch
         * [`fn withPrecisionThreshold(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountsettingswithprecisionthreshold)
   * [`obj PipelineMetricAggregation`](#obj-metricspipelinemetricaggregation)
     * [`obj BucketScript`](#obj-metricspipelinemetricaggregationbucketscript)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariablesmixin)
@@ -306,7 +306,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricspipelinemetricaggregationbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricspipelinemetricaggregationcumulativesum)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithsettings)
@@ -316,7 +316,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricspipelinemetricaggregationcumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricspipelinemetricaggregationderivative)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationderivativewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationderivativewithsettings)
@@ -326,7 +326,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricspipelinemetricaggregationderivativesettingswithunit)
     * [`obj MovingAverage`](#obj-metricspipelinemetricaggregationmovingaverage)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithsettings)
@@ -373,7 +373,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -849,7 +849,7 @@ withSize(value)
 ##### fn metrics.Count.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -887,7 +887,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Average.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -968,7 +968,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1084,7 +1084,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1154,7 +1154,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1224,7 +1224,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.ExtendedStats.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1329,7 +1329,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.Logs.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1391,7 +1391,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Max.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1480,7 +1480,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Min.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1569,7 +1569,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1628,7 +1628,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingFunction.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1733,7 +1733,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Percentiles.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1838,7 +1838,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Rate.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1900,7 +1900,7 @@ withUnit(value)
 ###### fn metrics.MetricAggregationWithSettings.RawData.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1954,7 +1954,7 @@ withSize(value)
 ###### fn metrics.MetricAggregationWithSettings.RawDocument.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2016,7 +2016,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.SerialDiff.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2086,7 +2086,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Sum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2167,7 +2167,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.TopMetrics.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2253,7 +2253,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.UniqueCount.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2318,7 +2318,7 @@ withPrecisionThreshold(value)
 ###### fn metrics.PipelineMetricAggregation.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2434,7 +2434,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2504,7 +2504,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2574,7 +2574,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 

--- a/docs/API/query/grafanaPyroscope.md
+++ b/docs/API/query/grafanaPyroscope.md
@@ -7,7 +7,7 @@ grafonnet.query.grafanaPyroscope
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGroupBy(value)`](#fn-withgroupby)
 * [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withMaxNodes(value)`](#fn-withmaxnodes)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
@@ -46,7 +46,7 @@ Allows to group the results.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/docs/API/query/loki.md
+++ b/docs/API/query/loki.md
@@ -8,12 +8,12 @@ grafonnet.query.loki
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
 * [`fn withExpr(value)`](#fn-withexpr)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withMaxLines(value)`](#fn-withmaxlines)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 * [`fn withResolution(value)`](#fn-withresolution)
 
@@ -56,7 +56,7 @@ The LogQL query.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -66,7 +66,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 @deprecated, now use queryType.
@@ -99,7 +99,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 @deprecated, now use queryType.

--- a/docs/API/query/parca.md
+++ b/docs/API/query/parca.md
@@ -5,7 +5,7 @@ grafonnet.query.parca
 ## Index
 
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -27,7 +27,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/docs/API/query/prometheus.md
+++ b/docs/API/query/prometheus.md
@@ -7,15 +7,15 @@ grafonnet.query.prometheus
 * [`fn new(datasource, expr)`](#fn-new)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
-* [`fn withExemplar(value)`](#fn-withexemplar)
+* [`fn withExemplar(value=true)`](#fn-withexemplar)
 * [`fn withExpr(value)`](#fn-withexpr)
 * [`fn withFormat(value)`](#fn-withformat)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withIntervalFactor(value)`](#fn-withintervalfactor)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 
 ## Fields
@@ -49,7 +49,7 @@ Accepted values for `value` are "code", "builder"
 ### fn withExemplar
 
 ```ts
-withExemplar(value)
+withExemplar(value=true)
 ```
 
 Execute an additional query to identify interesting raw samples relevant for the given expr
@@ -75,7 +75,7 @@ Accepted values for `value` are "time_series", "table", "heatmap"
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -85,7 +85,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 Returns only the latest value that Prometheus has scraped for the requested time series
@@ -118,7 +118,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series

--- a/docs/API/query/tempo.md
+++ b/docs/API/query/tempo.md
@@ -8,7 +8,7 @@ grafonnet.query.tempo
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withFilters(value)`](#fn-withfilters)
 * [`fn withFiltersMixin(value)`](#fn-withfiltersmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLimit(value)`](#fn-withlimit)
 * [`fn withMaxDuration(value)`](#fn-withmaxduration)
 * [`fn withMinDuration(value)`](#fn-withminduration)
@@ -65,7 +65,7 @@ withFiltersMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/docs/API/query/testData.md
+++ b/docs/API/query/testData.md
@@ -12,9 +12,9 @@ grafonnet.query.testData
 * [`fn withCsvWaveMixin(value)`](#fn-withcsvwavemixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withErrorType(value)`](#fn-witherrortype)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabels(value)`](#fn-withlabels)
-* [`fn withLevelColumn(value)`](#fn-withlevelcolumn)
+* [`fn withLevelColumn(value=true)`](#fn-withlevelcolumn)
 * [`fn withLines(value)`](#fn-withlines)
 * [`fn withNodes(value)`](#fn-withnodes)
 * [`fn withNodesMixin(value)`](#fn-withnodesmixin)
@@ -54,8 +54,8 @@ grafonnet.query.testData
   * [`fn withConfigMixin(value)`](#fn-simwithconfigmixin)
   * [`fn withKey(value)`](#fn-simwithkey)
   * [`fn withKeyMixin(value)`](#fn-simwithkeymixin)
-  * [`fn withLast(value)`](#fn-simwithlast)
-  * [`fn withStream(value)`](#fn-simwithstream)
+  * [`fn withLast(value=true)`](#fn-simwithlast)
+  * [`fn withStream(value=true)`](#fn-simwithstream)
   * [`obj key`](#obj-simkey)
     * [`fn withTick(value)`](#fn-simkeywithtick)
     * [`fn withType(value)`](#fn-simkeywithtype)
@@ -149,7 +149,7 @@ Accepted values for `value` are "server_panic", "frontend_exception", "frontend_
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -167,7 +167,7 @@ withLabels(value)
 ### fn withLevelColumn
 
 ```ts
-withLevelColumn(value)
+withLevelColumn(value=true)
 ```
 
 
@@ -474,7 +474,7 @@ withKeyMixin(value)
 #### fn sim.withLast
 
 ```ts
-withLast(value)
+withLast(value=true)
 ```
 
 
@@ -482,7 +482,7 @@ withLast(value)
 #### fn sim.withStream
 
 ```ts
-withStream(value)
+withStream(value=true)
 ```
 
 

--- a/docs/API/serviceaccount.md
+++ b/docs/API/serviceaccount.md
@@ -8,7 +8,7 @@ grafonnet.serviceaccount
 * [`fn withAccessControlMixin(value)`](#fn-withaccesscontrolmixin)
 * [`fn withAvatarUrl(value)`](#fn-withavatarurl)
 * [`fn withId(value)`](#fn-withid)
-* [`fn withIsDisabled(value)`](#fn-withisdisabled)
+* [`fn withIsDisabled(value=true)`](#fn-withisdisabled)
 * [`fn withLogin(value)`](#fn-withlogin)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withOrgId(value)`](#fn-withorgid)
@@ -55,7 +55,7 @@ ID is the unique identifier of the service account in the database.
 ### fn withIsDisabled
 
 ```ts
-withIsDisabled(value)
+withIsDisabled(value=true)
 ```
 
 IsDisabled indicates if the service account is disabled.

--- a/docs/API/util.md
+++ b/docs/API/util.md
@@ -7,7 +7,8 @@ Helper functions that work well with Grafonnet.
 * [`obj dashboard`](#obj-dashboard)
   * [`fn getOptionsForCustomQuery(query)`](#fn-dashboardgetoptionsforcustomquery)
 * [`obj grid`](#obj-grid)
-  * [`fn makeGrid(panels, panelWidth, panelHeight)`](#fn-gridmakegrid)
+  * [`fn makeGrid(panels, panelWidth, panelHeight, startY)`](#fn-gridmakegrid)
+  * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
 * [`obj string`](#obj-string)
@@ -40,7 +41,7 @@ compatible solution.
 #### fn grid.makeGrid
 
 ```ts
-makeGrid(panels, panelWidth, panelHeight)
+makeGrid(panels, panelWidth, panelHeight, startY)
 ```
 
 `makeGrid` returns an array of `panels` organized in a grid with equal `panelWidth`
@@ -50,6 +51,18 @@ then all panels below it will be folded into the row.
 This function will use the full grid of 24 columns, setting `panelWidth` to a value
 that can divide 24 into equal parts will fill up the page nicely. (1, 2, 3, 4, 6, 8, 12)
 Other value for `panelWidth` will leave a gap on the far right.
+
+Optional `startY` can be provided to place generated grid above or below existing panels.
+
+
+#### fn grid.wrapPanels
+
+```ts
+wrapPanels(panels, panelWidth, panelHeight, startY)
+```
+
+`wrapPanels` returns an array of `panels` organized in a grid, wrapping up to next 'row' if total width exceeds full grid of 24 columns.
+'panelHeight' and 'panelWidth' are used unless panels already have height and width defined.
 
 
 ### obj panel

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/annotation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/annotation.md
@@ -9,7 +9,7 @@
 * [`fn withEnable(value=true)`](#fn-withenable)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
-* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withIconColor(value)`](#fn-withiconcolor)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withTarget(value)`](#fn-withtarget)
@@ -19,12 +19,12 @@
   * [`fn withType(value)`](#fn-datasourcewithtype)
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj filter`](#obj-filter)
-  * [`fn withExclude(value=false)`](#fn-filterwithexclude)
+  * [`fn withExclude(value=true)`](#fn-filterwithexclude)
   * [`fn withIds(value)`](#fn-filterwithids)
   * [`fn withIdsMixin(value)`](#fn-filterwithidsmixin)
 * [`obj target`](#obj-target)
   * [`fn withLimit(value)`](#fn-targetwithlimit)
-  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withMatchAny(value=true)`](#fn-targetwithmatchany)
   * [`fn withTags(value)`](#fn-targetwithtags)
   * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
   * [`fn withType(value)`](#fn-targetwithtype)
@@ -74,7 +74,7 @@ withFilterMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value=false)
+withHide(value=true)
 ```
 
 Annotation queries can be toggled on or off at the top of the dashboard.
@@ -147,7 +147,7 @@ withUid(value)
 #### fn filter.withExclude
 
 ```ts
-withExclude(value=false)
+withExclude(value=true)
 ```
 
 Should the specified panels be included or excluded
@@ -183,7 +183,7 @@ but code+tests is already depending on it so hard to change
 #### fn target.withMatchAny
 
 ```ts
-withMatchAny(value)
+withMatchAny(value=true)
 ```
 
 Only required/valid for the grafana datasource...

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/index.md
@@ -18,7 +18,7 @@ grafonnet.dashboard
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
-* [`fn withLiveNow(value)`](#fn-withlivenow)
+* [`fn withLiveNow(value=true)`](#fn-withlivenow)
 * [`fn withPanels(value)`](#fn-withpanels)
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
@@ -42,9 +42,9 @@ grafonnet.dashboard
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
 * [`obj timepicker`](#obj-timepicker)
-  * [`fn withCollapse(value=false)`](#fn-timepickerwithcollapse)
+  * [`fn withCollapse(value=true)`](#fn-timepickerwithcollapse)
   * [`fn withEnable(value=true)`](#fn-timepickerwithenable)
-  * [`fn withHidden(value=false)`](#fn-timepickerwithhidden)
+  * [`fn withHidden(value=true)`](#fn-timepickerwithhidden)
   * [`fn withRefreshIntervals(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervals)
   * [`fn withRefreshIntervalsMixin(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervalsmixin)
   * [`fn withTimeOptions(value=["5m","15m","1h","6h","12h","24h","2d","7d","30d"])`](#fn-timepickerwithtimeoptions)
@@ -159,7 +159,7 @@ g.dashboard.new('Title dashboard')
 ### fn withLiveNow
 
 ```ts
-withLiveNow(value)
+withLiveNow(value=true)
 ```
 
 When set to true, the dashboard will redraw panels at an interval matching the pixel width.
@@ -346,7 +346,7 @@ withTo(value="now")
 #### fn timepicker.withCollapse
 
 ```ts
-withCollapse(value=false)
+withCollapse(value=true)
 ```
 
 Whether timepicker is collapsed or not.
@@ -362,7 +362,7 @@ Whether timepicker is enabled or not.
 #### fn timepicker.withHidden
 
 ```ts
-withHidden(value=false)
+withHidden(value=true)
 ```
 
 Whether timepicker is visible or not.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/link.md
@@ -22,19 +22,19 @@ g.dashboard.new('Title dashboard')
 * [`obj dashboards`](#obj-dashboards)
   * [`fn new(title, tags)`](#fn-dashboardsnew)
   * [`obj options`](#obj-dashboardsoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-dashboardsoptionswithtargetblank)
 * [`obj link`](#obj-link)
   * [`fn new(title, url)`](#fn-linknew)
   * [`fn withIcon(value)`](#fn-linkwithicon)
   * [`fn withTooltip(value)`](#fn-linkwithtooltip)
   * [`obj options`](#obj-linkoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-linkoptionswithtargetblank)
 
 ## Fields
 
@@ -56,7 +56,7 @@ Create links to dashboards based on `tags`.
 ##### fn dashboards.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -64,7 +64,7 @@ withAsDropdown(value=false)
 ##### fn dashboards.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -72,7 +72,7 @@ withIncludeVars(value=false)
 ##### fn dashboards.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -80,7 +80,7 @@ withKeepTime(value=false)
 ##### fn dashboards.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 
@@ -119,7 +119,7 @@ withTooltip(value)
 ##### fn link.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -127,7 +127,7 @@ withAsDropdown(value=false)
 ##### fn link.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -135,7 +135,7 @@ withIncludeVars(value=false)
 ##### fn link.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -143,7 +143,7 @@ withKeepTime(value=false)
 ##### fn link.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/variable.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/dashboard/variable.md
@@ -113,7 +113,7 @@ g.dashboard.new('my dashboard')
       * [`fn withNothing()`](#fn-querygeneraloptionsshowondashboardwithnothing)
       * [`fn withValueOnly()`](#fn-querygeneraloptionsshowondashboardwithvalueonly)
   * [`obj queryTypes`](#obj-queryquerytypes)
-    * [`fn withLabelValues(label, metric)`](#fn-queryquerytypeswithlabelvalues)
+    * [`fn withLabelValues(label, metric="")`](#fn-queryquerytypeswithlabelvalues)
   * [`obj refresh`](#obj-queryrefresh)
     * [`fn onLoad()`](#fn-queryrefreshonload)
     * [`fn onTime()`](#fn-queryrefreshontime)
@@ -668,7 +668,7 @@ withValueOnly()
 ##### fn query.queryTypes.withLabelValues
 
 ```ts
-withLabelValues(label, metric)
+withLabelValues(label, metric="")
 ```
 
 Construct a Prometheus template variable using `label_values()`.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,7 +27,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withAlertmanager(value)`](#fn-optionswithalertmanager)
-  * [`fn withExpandAll(value)`](#fn-optionswithexpandall)
+  * [`fn withExpandAll(value=true)`](#fn-optionswithexpandall)
   * [`fn withLabels(value)`](#fn-optionswithlabels)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -36,7 +36,7 @@ grafonnet.panel.alertGroups
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -113,7 +113,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -175,7 +175,7 @@ Name of the alertmanager used as a source for alerts
 #### fn options.withExpandAll
 
 ```ts
-withExpandAll(value)
+withExpandAll(value=true)
 ```
 
 Expand all alert groups by default
@@ -248,7 +248,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/alertGroups/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.annotationsList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,8 +30,8 @@ grafonnet.panel.annotationsList
   * [`fn withNavigateAfter(value="10m")`](#fn-optionswithnavigateafter)
   * [`fn withNavigateBefore(value="10m")`](#fn-optionswithnavigatebefore)
   * [`fn withNavigateToPanel(value=true)`](#fn-optionswithnavigatetopanel)
-  * [`fn withOnlyFromThisDashboard(value=false)`](#fn-optionswithonlyfromthisdashboard)
-  * [`fn withOnlyInTimeRange(value=false)`](#fn-optionswithonlyintimerange)
+  * [`fn withOnlyFromThisDashboard(value=true)`](#fn-optionswithonlyfromthisdashboard)
+  * [`fn withOnlyInTimeRange(value=true)`](#fn-optionswithonlyintimerange)
   * [`fn withShowTags(value=true)`](#fn-optionswithshowtags)
   * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withShowUser(value=true)`](#fn-optionswithshowuser)
@@ -44,7 +44,7 @@ grafonnet.panel.annotationsList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -207,7 +207,7 @@ withNavigateToPanel(value=true)
 #### fn options.withOnlyFromThisDashboard
 
 ```ts
-withOnlyFromThisDashboard(value=false)
+withOnlyFromThisDashboard(value=true)
 ```
 
 
@@ -215,7 +215,7 @@ withOnlyFromThisDashboard(value=false)
 #### fn options.withOnlyInTimeRange
 
 ```ts
-withOnlyInTimeRange(value=false)
+withOnlyInTimeRange(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/annotationsList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.barChart
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -37,9 +37,9 @@ grafonnet.panel.barChart
       * [`fn withThresholdsStyle(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstyle)
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
@@ -48,7 +48,7 @@ grafonnet.panel.barChart
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -59,7 +59,7 @@ grafonnet.panel.barChart
   * [`fn withBarRadius(value=0)`](#fn-optionswithbarradius)
   * [`fn withBarWidth(value=0.97)`](#fn-optionswithbarwidth)
   * [`fn withColorByField(value)`](#fn-optionswithcolorbyfield)
-  * [`fn withFullHighlight(value=false)`](#fn-optionswithfullhighlight)
+  * [`fn withFullHighlight(value=true)`](#fn-optionswithfullhighlight)
   * [`fn withGroupWidth(value=0.7)`](#fn-optionswithgroupwidth)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
@@ -75,15 +75,15 @@ grafonnet.panel.barChart
   * [`fn withXTickLabelRotation(value=0)`](#fn-optionswithxticklabelrotation)
   * [`fn withXTickLabelSpacing(value=0)`](#fn-optionswithxticklabelspacing)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
@@ -98,7 +98,7 @@ grafonnet.panel.barChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -317,7 +317,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -325,7 +325,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -333,7 +333,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -394,7 +394,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -472,7 +472,7 @@ Use the color value for a sibling field to color each bar value.
 #### fn options.withFullHighlight
 
 ```ts
-withFullHighlight(value=false)
+withFullHighlight(value=true)
 ```
 
 Enables mode which highlights the entire bar area and shows tooltip when cursor
@@ -597,7 +597,7 @@ negative values indicate backwards skipping behavior
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -632,7 +632,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -650,7 +650,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -666,7 +666,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.barGauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.barGauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -52,7 +52,7 @@ grafonnet.panel.barGauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -129,7 +129,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -305,7 +305,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -389,7 +389,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/barGauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.candlestick
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.candlestick
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/candlestick/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.canvas
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.canvas
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/canvas/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withFolderId(value)`](#fn-optionswithfolderid)
-  * [`fn withIncludeVars(value=false)`](#fn-optionswithincludevars)
-  * [`fn withKeepTime(value=false)`](#fn-optionswithkeeptime)
+  * [`fn withIncludeVars(value=true)`](#fn-optionswithincludevars)
+  * [`fn withKeepTime(value=true)`](#fn-optionswithkeeptime)
   * [`fn withMaxItems(value=10)`](#fn-optionswithmaxitems)
   * [`fn withQuery(value="")`](#fn-optionswithquery)
   * [`fn withShowHeadings(value=true)`](#fn-optionswithshowheadings)
-  * [`fn withShowRecentlyViewed(value=false)`](#fn-optionswithshowrecentlyviewed)
-  * [`fn withShowSearch(value=false)`](#fn-optionswithshowsearch)
+  * [`fn withShowRecentlyViewed(value=true)`](#fn-optionswithshowrecentlyviewed)
+  * [`fn withShowSearch(value=true)`](#fn-optionswithshowsearch)
   * [`fn withShowStarred(value=true)`](#fn-optionswithshowstarred)
   * [`fn withTags(value)`](#fn-optionswithtags)
   * [`fn withTagsMixin(value)`](#fn-optionswithtagsmixin)
@@ -44,7 +44,7 @@ grafonnet.panel.dashboardList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -183,7 +183,7 @@ withFolderId(value)
 #### fn options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ withIncludeVars(value=false)
 #### fn options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -223,7 +223,7 @@ withShowHeadings(value=true)
 #### fn options.withShowRecentlyViewed
 
 ```ts
-withShowRecentlyViewed(value=false)
+withShowRecentlyViewed(value=true)
 ```
 
 
@@ -231,7 +231,7 @@ withShowRecentlyViewed(value=false)
 #### fn options.withShowSearch
 
 ```ts
-withShowSearch(value=false)
+withShowSearch(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/dashboardList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.datagrid
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -34,7 +34,7 @@ grafonnet.panel.datagrid
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -111,7 +111,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -230,7 +230,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/datagrid/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.debug
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,9 +30,9 @@ grafonnet.panel.debug
   * [`fn withCountersMixin(value)`](#fn-optionswithcountersmixin)
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj counters`](#obj-optionscounters)
-    * [`fn withDataChanged(value)`](#fn-optionscounterswithdatachanged)
-    * [`fn withRender(value)`](#fn-optionscounterswithrender)
-    * [`fn withSchemaChanged(value)`](#fn-optionscounterswithschemachanged)
+    * [`fn withDataChanged(value=true)`](#fn-optionscounterswithdatachanged)
+    * [`fn withRender(value=true)`](#fn-optionscounterswithrender)
+    * [`fn withSchemaChanged(value=true)`](#fn-optionscounterswithschemachanged)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -40,7 +40,7 @@ grafonnet.panel.debug
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -117,7 +117,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -200,7 +200,7 @@ Accepted values for `value` are "render", "events", "cursor", "State", "ThrowErr
 ##### fn options.counters.withDataChanged
 
 ```ts
-withDataChanged(value)
+withDataChanged(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ withDataChanged(value)
 ##### fn options.counters.withRender
 
 ```ts
-withRender(value)
+withRender(value=true)
 ```
 
 
@@ -216,7 +216,7 @@ withRender(value)
 ##### fn options.counters.withSchemaChanged
 
 ```ts
-withSchemaChanged(value)
+withSchemaChanged(value=true)
 ```
 
 
@@ -281,7 +281,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/debug/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.gauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -29,7 +29,7 @@ grafonnet.panel.gauge
   * [`fn withOrientation(value)`](#fn-optionswithorientation)
   * [`fn withReduceOptions(value)`](#fn-optionswithreduceoptions)
   * [`fn withReduceOptionsMixin(value)`](#fn-optionswithreduceoptionsmixin)
-  * [`fn withShowThresholdLabels(value=false)`](#fn-optionswithshowthresholdlabels)
+  * [`fn withShowThresholdLabels(value=true)`](#fn-optionswithshowthresholdlabels)
   * [`fn withShowThresholdMarkers(value=true)`](#fn-optionswithshowthresholdmarkers)
   * [`fn withText(value)`](#fn-optionswithtext)
   * [`fn withTextMixin(value)`](#fn-optionswithtextmixin)
@@ -38,7 +38,7 @@ grafonnet.panel.gauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -49,7 +49,7 @@ grafonnet.panel.gauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -126,7 +126,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -206,7 +206,7 @@ TODO docs
 #### fn options.withShowThresholdLabels
 
 ```ts
-withShowThresholdLabels(value=false)
+withShowThresholdLabels(value=true)
 ```
 
 
@@ -273,7 +273,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -357,7 +357,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/gauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.geomap
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -43,7 +43,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionsbasemapwithlocationmixin)
     * [`fn withName(value)`](#fn-optionsbasemapwithname)
     * [`fn withOpacity(value)`](#fn-optionsbasemapwithopacity)
-    * [`fn withTooltip(value)`](#fn-optionsbasemapwithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionsbasemapwithtooltip)
     * [`fn withType(value)`](#fn-optionsbasemapwithtype)
     * [`obj location`](#obj-optionsbasemaplocation)
       * [`fn withGazetteer(value)`](#fn-optionsbasemaplocationwithgazetteer)
@@ -54,12 +54,12 @@ grafonnet.panel.geomap
       * [`fn withMode(value)`](#fn-optionsbasemaplocationwithmode)
       * [`fn withWkt(value)`](#fn-optionsbasemaplocationwithwkt)
   * [`obj controls`](#obj-optionscontrols)
-    * [`fn withMouseWheelZoom(value)`](#fn-optionscontrolswithmousewheelzoom)
-    * [`fn withShowAttribution(value)`](#fn-optionscontrolswithshowattribution)
-    * [`fn withShowDebug(value)`](#fn-optionscontrolswithshowdebug)
-    * [`fn withShowMeasure(value)`](#fn-optionscontrolswithshowmeasure)
-    * [`fn withShowScale(value)`](#fn-optionscontrolswithshowscale)
-    * [`fn withShowZoom(value)`](#fn-optionscontrolswithshowzoom)
+    * [`fn withMouseWheelZoom(value=true)`](#fn-optionscontrolswithmousewheelzoom)
+    * [`fn withShowAttribution(value=true)`](#fn-optionscontrolswithshowattribution)
+    * [`fn withShowDebug(value=true)`](#fn-optionscontrolswithshowdebug)
+    * [`fn withShowMeasure(value=true)`](#fn-optionscontrolswithshowmeasure)
+    * [`fn withShowScale(value=true)`](#fn-optionscontrolswithshowscale)
+    * [`fn withShowZoom(value=true)`](#fn-optionscontrolswithshowzoom)
   * [`obj layers`](#obj-optionslayers)
     * [`fn withConfig(value)`](#fn-optionslayerswithconfig)
     * [`fn withFilterData(value)`](#fn-optionslayerswithfilterdata)
@@ -67,7 +67,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionslayerswithlocationmixin)
     * [`fn withName(value)`](#fn-optionslayerswithname)
     * [`fn withOpacity(value)`](#fn-optionslayerswithopacity)
-    * [`fn withTooltip(value)`](#fn-optionslayerswithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionslayerswithtooltip)
     * [`fn withType(value)`](#fn-optionslayerswithtype)
     * [`obj location`](#obj-optionslayerslocation)
       * [`fn withGazetteer(value)`](#fn-optionslayerslocationwithgazetteer)
@@ -82,14 +82,14 @@ grafonnet.panel.geomap
   * [`obj view`](#obj-optionsview)
     * [`fn withAllLayers(value=true)`](#fn-optionsviewwithalllayers)
     * [`fn withId(value="zero")`](#fn-optionsviewwithid)
-    * [`fn withLastOnly(value)`](#fn-optionsviewwithlastonly)
+    * [`fn withLastOnly(value=true)`](#fn-optionsviewwithlastonly)
     * [`fn withLat(value=0)`](#fn-optionsviewwithlat)
     * [`fn withLayer(value)`](#fn-optionsviewwithlayer)
     * [`fn withLon(value=0)`](#fn-optionsviewwithlon)
     * [`fn withMaxZoom(value)`](#fn-optionsviewwithmaxzoom)
     * [`fn withMinZoom(value)`](#fn-optionsviewwithminzoom)
     * [`fn withPadding(value)`](#fn-optionsviewwithpadding)
-    * [`fn withShared(value)`](#fn-optionsviewwithshared)
+    * [`fn withShared(value=true)`](#fn-optionsviewwithshared)
     * [`fn withZoom(value=1)`](#fn-optionsviewwithzoom)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -98,7 +98,7 @@ grafonnet.panel.geomap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -175,7 +175,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -362,7 +362,7 @@ Layer opacity (0-1)
 ##### fn options.basemap.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -442,7 +442,7 @@ withWkt(value)
 ##### fn options.controls.withMouseWheelZoom
 
 ```ts
-withMouseWheelZoom(value)
+withMouseWheelZoom(value=true)
 ```
 
 let the mouse wheel zoom
@@ -450,7 +450,7 @@ let the mouse wheel zoom
 ##### fn options.controls.withShowAttribution
 
 ```ts
-withShowAttribution(value)
+withShowAttribution(value=true)
 ```
 
 Lower right
@@ -458,7 +458,7 @@ Lower right
 ##### fn options.controls.withShowDebug
 
 ```ts
-withShowDebug(value)
+withShowDebug(value=true)
 ```
 
 Show debug
@@ -466,7 +466,7 @@ Show debug
 ##### fn options.controls.withShowMeasure
 
 ```ts
-withShowMeasure(value)
+withShowMeasure(value=true)
 ```
 
 Show measure
@@ -474,7 +474,7 @@ Show measure
 ##### fn options.controls.withShowScale
 
 ```ts
-withShowScale(value)
+withShowScale(value=true)
 ```
 
 Scale options
@@ -482,7 +482,7 @@ Scale options
 ##### fn options.controls.withShowZoom
 
 ```ts
-withShowZoom(value)
+withShowZoom(value=true)
 ```
 
 Zoom (upper left)
@@ -543,7 +543,7 @@ Layer opacity (0-1)
 ##### fn options.layers.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -652,7 +652,7 @@ withId(value="zero")
 ##### fn options.view.withLastOnly
 
 ```ts
-withLastOnly(value)
+withLastOnly(value=true)
 ```
 
 
@@ -708,7 +708,7 @@ withPadding(value)
 ##### fn options.view.withShared
 
 ```ts
-withShared(value)
+withShared(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/geomap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/index.md
@@ -24,16 +24,16 @@ grafonnet.panel.heatmap
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.heatmap
   * [`fn withName(value)`](#fn-librarypanelwithname)
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
-  * [`fn withCalculate(value=false)`](#fn-optionswithcalculate)
+  * [`fn withCalculate(value=true)`](#fn-optionswithcalculate)
   * [`fn withCalculation(value)`](#fn-optionswithcalculation)
   * [`fn withCalculationMixin(value)`](#fn-optionswithcalculationmixin)
   * [`fn withCellGap(value=1)`](#fn-optionswithcellgap)
@@ -101,7 +101,7 @@ grafonnet.panel.heatmap
       * [`fn withMax(value)`](#fn-optionscolorheatmapcoloroptionswithmax)
       * [`fn withMin(value)`](#fn-optionscolorheatmapcoloroptionswithmin)
       * [`fn withMode(value)`](#fn-optionscolorheatmapcoloroptionswithmode)
-      * [`fn withReverse(value)`](#fn-optionscolorheatmapcoloroptionswithreverse)
+      * [`fn withReverse(value=true)`](#fn-optionscolorheatmapcoloroptionswithreverse)
       * [`fn withScale(value)`](#fn-optionscolorheatmapcoloroptionswithscale)
       * [`fn withScheme(value)`](#fn-optionscolorheatmapcoloroptionswithscheme)
       * [`fn withSteps(value)`](#fn-optionscolorheatmapcoloroptionswithsteps)
@@ -114,17 +114,17 @@ grafonnet.panel.heatmap
       * [`fn withGe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithge)
       * [`fn withLe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithle)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withShow(value)`](#fn-optionslegendwithshow)
+    * [`fn withShow(value=true)`](#fn-optionslegendwithshow)
   * [`obj rowsFrame`](#obj-optionsrowsframe)
     * [`fn withLayout(value)`](#fn-optionsrowsframewithlayout)
     * [`fn withValue(value)`](#fn-optionsrowsframewithvalue)
   * [`obj tooltip`](#obj-optionstooltip)
-    * [`fn withShow(value)`](#fn-optionstooltipwithshow)
-    * [`fn withYHistogram(value)`](#fn-optionstooltipwithyhistogram)
+    * [`fn withShow(value=true)`](#fn-optionstooltipwithshow)
+    * [`fn withYHistogram(value=true)`](#fn-optionstooltipwithyhistogram)
   * [`obj yAxis`](#obj-optionsyaxis)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsyaxiswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsyaxiswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsyaxiswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsyaxiswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsyaxiswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsyaxiswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsyaxiswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsyaxiswithaxissoftmax)
@@ -133,7 +133,7 @@ grafonnet.panel.heatmap
     * [`fn withDecimals(value)`](#fn-optionsyaxiswithdecimals)
     * [`fn withMax(value)`](#fn-optionsyaxiswithmax)
     * [`fn withMin(value)`](#fn-optionsyaxiswithmin)
-    * [`fn withReverse(value)`](#fn-optionsyaxiswithreverse)
+    * [`fn withReverse(value=true)`](#fn-optionsyaxiswithreverse)
     * [`fn withScaleDistribution(value)`](#fn-optionsyaxiswithscaledistribution)
     * [`fn withScaleDistributionMixin(value)`](#fn-optionsyaxiswithscaledistributionmixin)
     * [`fn withUnit(value)`](#fn-optionsyaxiswithunit)
@@ -148,7 +148,7 @@ grafonnet.panel.heatmap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -258,7 +258,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -266,7 +266,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -274,7 +274,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -322,7 +322,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -376,7 +376,7 @@ withUid(value)
 #### fn options.withCalculate
 
 ```ts
-withCalculate(value=false)
+withCalculate(value=true)
 ```
 
 Controls if the heatmap should be calculated from data
@@ -824,7 +824,7 @@ Accepted values for `value` are "opacity", "scheme"
 ###### fn options.color.HeatmapColorOptions.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the color scheme
@@ -910,7 +910,7 @@ Sets the filter range to values less than or equal to the given value
 ##### fn options.legend.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the legend is shown
@@ -942,7 +942,7 @@ Sets the name of the cell when not calculating from data
 ##### fn options.tooltip.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the tooltip is shown
@@ -950,7 +950,7 @@ Controls if the tooltip is shown
 ##### fn options.tooltip.withYHistogram
 
 ```ts
-withYHistogram(value)
+withYHistogram(value=true)
 ```
 
 Controls if the tooltip shows a histogram of the y-axis values
@@ -961,7 +961,7 @@ Controls if the tooltip shows a histogram of the y-axis values
 ##### fn options.yAxis.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -979,7 +979,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.yAxis.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -1053,7 +1053,7 @@ Sets the minimum value for the yAxis
 ##### fn options.yAxis.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the yAxis
@@ -1171,7 +1171,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/heatmap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.histogram
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -35,16 +35,16 @@ grafonnet.panel.histogram
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -54,21 +54,21 @@ grafonnet.panel.histogram
 * [`obj options`](#obj-options)
   * [`fn withBucketOffset(value=0)`](#fn-optionswithbucketoffset)
   * [`fn withBucketSize(value)`](#fn-optionswithbucketsize)
-  * [`fn withCombine(value)`](#fn-optionswithcombine)
+  * [`fn withCombine(value=true)`](#fn-optionswithcombine)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -80,7 +80,7 @@ grafonnet.panel.histogram
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -155,7 +155,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -173,7 +173,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -283,7 +283,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -291,7 +291,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -299,7 +299,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -347,7 +347,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -417,7 +417,7 @@ Size of each bucket
 #### fn options.withCombine
 
 ```ts
-withCombine(value)
+withCombine(value=true)
 ```
 
 Combines multiple series into a single histogram
@@ -460,7 +460,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -495,7 +495,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -513,7 +513,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -529,7 +529,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -625,7 +625,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/histogram/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withDedupStrategy(value)`](#fn-optionswithdedupstrategy)
-  * [`fn withEnableLogDetails(value)`](#fn-optionswithenablelogdetails)
-  * [`fn withPrettifyLogMessage(value)`](#fn-optionswithprettifylogmessage)
-  * [`fn withShowCommonLabels(value)`](#fn-optionswithshowcommonlabels)
-  * [`fn withShowLabels(value)`](#fn-optionswithshowlabels)
-  * [`fn withShowTime(value)`](#fn-optionswithshowtime)
+  * [`fn withEnableLogDetails(value=true)`](#fn-optionswithenablelogdetails)
+  * [`fn withPrettifyLogMessage(value=true)`](#fn-optionswithprettifylogmessage)
+  * [`fn withShowCommonLabels(value=true)`](#fn-optionswithshowcommonlabels)
+  * [`fn withShowLabels(value=true)`](#fn-optionswithshowlabels)
+  * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withSortOrder(value)`](#fn-optionswithsortorder)
-  * [`fn withWrapLogMessage(value)`](#fn-optionswithwraplogmessage)
+  * [`fn withWrapLogMessage(value=true)`](#fn-optionswithwraplogmessage)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.logs
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -182,7 +182,7 @@ Accepted values for `value` are "none", "exact", "numbers", "signature"
 #### fn options.withEnableLogDetails
 
 ```ts
-withEnableLogDetails(value)
+withEnableLogDetails(value=true)
 ```
 
 
@@ -190,7 +190,7 @@ withEnableLogDetails(value)
 #### fn options.withPrettifyLogMessage
 
 ```ts
-withPrettifyLogMessage(value)
+withPrettifyLogMessage(value=true)
 ```
 
 
@@ -198,7 +198,7 @@ withPrettifyLogMessage(value)
 #### fn options.withShowCommonLabels
 
 ```ts
-withShowCommonLabels(value)
+withShowCommonLabels(value=true)
 ```
 
 
@@ -206,7 +206,7 @@ withShowCommonLabels(value)
 #### fn options.withShowLabels
 
 ```ts
-withShowLabels(value)
+withShowLabels(value=true)
 ```
 
 
@@ -214,7 +214,7 @@ withShowLabels(value)
 #### fn options.withShowTime
 
 ```ts
-withShowTime(value)
+withShowTime(value=true)
 ```
 
 
@@ -232,7 +232,7 @@ Accepted values for `value` are "Descending", "Ascending"
 #### fn options.withWrapLogMessage
 
 ```ts
-withWrapLogMessage(value)
+withWrapLogMessage(value=true)
 ```
 
 
@@ -297,7 +297,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/logs/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.news
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -35,7 +35,7 @@ grafonnet.panel.news
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -112,7 +112,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -239,7 +239,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/news/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.nodeGraph
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,7 +48,7 @@ grafonnet.panel.nodeGraph
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -125,7 +125,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/nodeGraph/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/index.md
@@ -22,12 +22,12 @@ grafonnet.panel.pieChart
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.pieChart
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withValues(value)`](#fn-optionslegendwithvalues)
     * [`fn withValuesMixin(value)`](#fn-optionslegendwithvaluesmixin)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
@@ -65,7 +65,7 @@ grafonnet.panel.pieChart
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -79,7 +79,7 @@ grafonnet.panel.pieChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -181,7 +181,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -189,7 +189,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -365,7 +365,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -400,7 +400,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -418,7 +418,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -434,7 +434,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -501,7 +501,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -608,7 +608,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/pieChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/row.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/row.md
@@ -5,7 +5,7 @@ grafonnet.panel.row
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withCollapsed(value=false)`](#fn-withcollapsed)
+* [`fn withCollapsed(value=true)`](#fn-withcollapsed)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withGridPos(value)`](#fn-withgridpos)
@@ -21,7 +21,7 @@ grafonnet.panel.row
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -39,7 +39,7 @@ Creates a new row panel with a title.
 ### fn withCollapsed
 
 ```ts
-withCollapsed(value=false)
+withCollapsed(value=true)
 ```
 
 
@@ -157,7 +157,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.stat
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -40,7 +40,7 @@ grafonnet.panel.stat
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -51,7 +51,7 @@ grafonnet.panel.stat
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -128,7 +128,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -299,7 +299,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -383,7 +383,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stat/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.stateTimeline
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=0)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.stateTimeline
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -68,7 +68,7 @@ grafonnet.panel.stateTimeline
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -178,7 +178,7 @@ withLineWidth(value=0)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -186,7 +186,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -194,7 +194,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -213,7 +213,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -350,7 +350,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -385,7 +385,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -403,7 +403,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -419,7 +419,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -515,7 +515,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/stateTimeline/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.statusHistory
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=1)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -47,15 +47,15 @@ grafonnet.panel.statusHistory
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -67,7 +67,7 @@ grafonnet.panel.statusHistory
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -177,7 +177,7 @@ withLineWidth(value=1)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -185,7 +185,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -193,7 +193,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -212,7 +212,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -376,7 +376,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -394,7 +394,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -410,7 +410,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -506,7 +506,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/statusHistory/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.table
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,22 +31,22 @@ grafonnet.panel.table
   * [`fn withFooterMixin(value={"countRows": false,"reducer": [],"show": false})`](#fn-optionswithfootermixin)
   * [`fn withFrameIndex(value=0)`](#fn-optionswithframeindex)
   * [`fn withShowHeader(value=true)`](#fn-optionswithshowheader)
-  * [`fn withShowTypeIcons(value=false)`](#fn-optionswithshowtypeicons)
+  * [`fn withShowTypeIcons(value=true)`](#fn-optionswithshowtypeicons)
   * [`fn withSortBy(value)`](#fn-optionswithsortby)
   * [`fn withSortByMixin(value)`](#fn-optionswithsortbymixin)
   * [`obj footer`](#obj-optionsfooter)
     * [`fn withTableFooterOptions(value)`](#fn-optionsfooterwithtablefooteroptions)
     * [`fn withTableFooterOptionsMixin(value)`](#fn-optionsfooterwithtablefooteroptionsmixin)
     * [`obj TableFooterOptions`](#obj-optionsfootertablefooteroptions)
-      * [`fn withCountRows(value)`](#fn-optionsfootertablefooteroptionswithcountrows)
-      * [`fn withEnablePagination(value)`](#fn-optionsfootertablefooteroptionswithenablepagination)
+      * [`fn withCountRows(value=true)`](#fn-optionsfootertablefooteroptionswithcountrows)
+      * [`fn withEnablePagination(value=true)`](#fn-optionsfootertablefooteroptionswithenablepagination)
       * [`fn withFields(value)`](#fn-optionsfootertablefooteroptionswithfields)
       * [`fn withFieldsMixin(value)`](#fn-optionsfootertablefooteroptionswithfieldsmixin)
       * [`fn withReducer(value)`](#fn-optionsfootertablefooteroptionswithreducer)
       * [`fn withReducerMixin(value)`](#fn-optionsfootertablefooteroptionswithreducermixin)
-      * [`fn withShow(value)`](#fn-optionsfootertablefooteroptionswithshow)
+      * [`fn withShow(value=true)`](#fn-optionsfootertablefooteroptionswithshow)
   * [`obj sortBy`](#obj-optionssortby)
-    * [`fn withDesc(value)`](#fn-optionssortbywithdesc)
+    * [`fn withDesc(value=true)`](#fn-optionssortbywithdesc)
     * [`fn withDisplayName(value)`](#fn-optionssortbywithdisplayname)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -55,7 +55,7 @@ grafonnet.panel.table
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -132,7 +132,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -226,7 +226,7 @@ Controls whether the panel should show the header
 #### fn options.withShowTypeIcons
 
 ```ts
-withShowTypeIcons(value=false)
+withShowTypeIcons(value=true)
 ```
 
 Controls whether the header should show icons for the column types
@@ -272,7 +272,7 @@ Footer options
 ###### fn options.footer.TableFooterOptions.withCountRows
 
 ```ts
-withCountRows(value)
+withCountRows(value=true)
 ```
 
 
@@ -280,7 +280,7 @@ withCountRows(value)
 ###### fn options.footer.TableFooterOptions.withEnablePagination
 
 ```ts
-withEnablePagination(value)
+withEnablePagination(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ withReducerMixin(value)
 ###### fn options.footer.TableFooterOptions.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 
@@ -331,7 +331,7 @@ withShow(value)
 ##### fn options.sortBy.withDesc
 
 ```ts
-withDesc(value)
+withDesc(value=true)
 ```
 
 Flag used to indicate descending sort order
@@ -404,7 +404,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/table/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.text
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,8 +32,8 @@ grafonnet.panel.text
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj code`](#obj-optionscode)
     * [`fn withLanguage(value="plaintext")`](#fn-optionscodewithlanguage)
-    * [`fn withShowLineNumbers(value=false)`](#fn-optionscodewithshowlinenumbers)
-    * [`fn withShowMiniMap(value=false)`](#fn-optionscodewithshowminimap)
+    * [`fn withShowLineNumbers(value=true)`](#fn-optionscodewithshowlinenumbers)
+    * [`fn withShowMiniMap(value=true)`](#fn-optionscodewithshowminimap)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.text
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -219,7 +219,7 @@ Accepted values for `value` are "plaintext", "yaml", "xml", "typescript", "sql",
 ##### fn options.code.withShowLineNumbers
 
 ```ts
-withShowLineNumbers(value=false)
+withShowLineNumbers(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withShowLineNumbers(value=false)
 ##### fn options.code.withShowMiniMap
 
 ```ts
-withShowMiniMap(value=false)
+withShowMiniMap(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/text/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.timeSeries
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.timeSeries
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -89,15 +89,15 @@ grafonnet.panel.timeSeries
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -109,7 +109,7 @@ grafonnet.panel.timeSeries
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -184,7 +184,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -202,7 +202,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -495,7 +495,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -503,7 +503,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -511,7 +511,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -622,7 +622,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -727,7 +727,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -762,7 +762,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -780,7 +780,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -796,7 +796,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -892,7 +892,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/timeSeries/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.trend
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.trend
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.trend
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -88,15 +88,15 @@ grafonnet.panel.trend
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`fn withXField(value)`](#fn-optionswithxfield)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -108,7 +108,7 @@ grafonnet.panel.trend
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -183,7 +183,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -201,7 +201,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -494,7 +494,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -502,7 +502,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -510,7 +510,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -621,7 +621,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -718,7 +718,7 @@ Name of the x field to use (defaults to first number)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -753,7 +753,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -771,7 +771,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -787,7 +787,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -883,7 +883,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/trend/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.xyChart
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,20 +41,20 @@ grafonnet.panel.xyChart
     * [`fn withFrame(value)`](#fn-optionsdimswithframe)
     * [`fn withX(value)`](#fn-optionsdimswithx)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj series`](#obj-optionsseries)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsserieswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsserieswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsserieswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsserieswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsserieswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsserieswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsserieswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsserieswithaxissoftmax)
@@ -81,9 +81,9 @@ grafonnet.panel.xyChart
     * [`fn withX(value)`](#fn-optionsserieswithx)
     * [`fn withY(value)`](#fn-optionsserieswithy)
     * [`obj hideFrom`](#obj-optionsserieshidefrom)
-      * [`fn withLegend(value)`](#fn-optionsserieshidefromwithlegend)
-      * [`fn withTooltip(value)`](#fn-optionsserieshidefromwithtooltip)
-      * [`fn withViz(value)`](#fn-optionsserieshidefromwithviz)
+      * [`fn withLegend(value=true)`](#fn-optionsserieshidefromwithlegend)
+      * [`fn withTooltip(value=true)`](#fn-optionsserieshidefromwithtooltip)
+      * [`fn withViz(value=true)`](#fn-optionsserieshidefromwithviz)
     * [`obj labelValue`](#obj-optionsserieslabelvalue)
       * [`fn withField(value)`](#fn-optionsserieslabelvaluewithfield)
       * [`fn withFixed(value)`](#fn-optionsserieslabelvaluewithfixed)
@@ -118,7 +118,7 @@ grafonnet.panel.xyChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -195,7 +195,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -361,7 +361,7 @@ withX(value)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -396,7 +396,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -414,7 +414,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -430,7 +430,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -449,7 +449,7 @@ withWidth(value)
 ##### fn options.series.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -467,7 +467,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.series.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -684,7 +684,7 @@ withY(value)
 ###### fn options.series.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -692,7 +692,7 @@ withLegend(value)
 ###### fn options.series.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -700,7 +700,7 @@ withTooltip(value)
 ###### fn options.series.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -958,7 +958,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/link.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/transformation.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/panel/xyChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/publicdashboard.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/publicdashboard.md
@@ -5,10 +5,10 @@ grafonnet.publicdashboard
 ## Index
 
 * [`fn withAccessToken(value)`](#fn-withaccesstoken)
-* [`fn withAnnotationsEnabled(value)`](#fn-withannotationsenabled)
+* [`fn withAnnotationsEnabled(value=true)`](#fn-withannotationsenabled)
 * [`fn withDashboardUid(value)`](#fn-withdashboarduid)
-* [`fn withIsEnabled(value)`](#fn-withisenabled)
-* [`fn withTimeSelectionEnabled(value)`](#fn-withtimeselectionenabled)
+* [`fn withIsEnabled(value=true)`](#fn-withisenabled)
+* [`fn withTimeSelectionEnabled(value=true)`](#fn-withtimeselectionenabled)
 * [`fn withUid(value)`](#fn-withuid)
 
 ## Fields
@@ -24,7 +24,7 @@ Unique public access token
 ### fn withAnnotationsEnabled
 
 ```ts
-withAnnotationsEnabled(value)
+withAnnotationsEnabled(value=true)
 ```
 
 Flag that indicates if annotations are enabled
@@ -40,7 +40,7 @@ Dashboard unique identifier referenced by this public dashboard
 ### fn withIsEnabled
 
 ```ts
-withIsEnabled(value)
+withIsEnabled(value=true)
 ```
 
 Flag that indicates if the public dashboard is enabled
@@ -48,7 +48,7 @@ Flag that indicates if the public dashboard is enabled
 ### fn withTimeSelectionEnabled
 
 ```ts
-withTimeSelectionEnabled(value)
+withTimeSelectionEnabled(value=true)
 ```
 
 Flag that indicates if the time range picker is enabled

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/azureMonitor.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/azureMonitor.md
@@ -15,7 +15,7 @@ grafonnet.query.azureMonitor
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGrafanaTemplateVariableFn(value)`](#fn-withgrafanatemplatevariablefn)
 * [`fn withGrafanaTemplateVariableFnMixin(value)`](#fn-withgrafanatemplatevariablefnmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withNamespace(value)`](#fn-withnamespace)
 * [`fn withQueryType(value)`](#fn-withquerytype)
 * [`fn withRefId(value)`](#fn-withrefid)
@@ -250,7 +250,7 @@ withGrafanaTemplateVariableFnMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/cloudWatch.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/cloudWatch.md
@@ -11,12 +11,12 @@ grafonnet.query.cloudWatch
   * [`fn withDatasource(value)`](#fn-cloudwatchannotationquerywithdatasource)
   * [`fn withDimensions(value)`](#fn-cloudwatchannotationquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchannotationquerywithdimensionsmixin)
-  * [`fn withHide(value)`](#fn-cloudwatchannotationquerywithhide)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchannotationquerywithmatchexact)
+  * [`fn withHide(value=true)`](#fn-cloudwatchannotationquerywithhide)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchannotationquerywithmatchexact)
   * [`fn withMetricName(value)`](#fn-cloudwatchannotationquerywithmetricname)
   * [`fn withNamespace(value)`](#fn-cloudwatchannotationquerywithnamespace)
   * [`fn withPeriod(value)`](#fn-cloudwatchannotationquerywithperiod)
-  * [`fn withPrefixMatching(value)`](#fn-cloudwatchannotationquerywithprefixmatching)
+  * [`fn withPrefixMatching(value=true)`](#fn-cloudwatchannotationquerywithprefixmatching)
   * [`fn withQueryMode(value)`](#fn-cloudwatchannotationquerywithquerymode)
   * [`fn withQueryType(value)`](#fn-cloudwatchannotationquerywithquerytype)
   * [`fn withRefId(value)`](#fn-cloudwatchannotationquerywithrefid)
@@ -27,7 +27,7 @@ grafonnet.query.cloudWatch
 * [`obj CloudWatchLogsQuery`](#obj-cloudwatchlogsquery)
   * [`fn withDatasource(value)`](#fn-cloudwatchlogsquerywithdatasource)
   * [`fn withExpression(value)`](#fn-cloudwatchlogsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchlogsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchlogsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchlogsquerywithid)
   * [`fn withLogGroupNames(value)`](#fn-cloudwatchlogsquerywithloggroupnames)
   * [`fn withLogGroupNamesMixin(value)`](#fn-cloudwatchlogsquerywithloggroupnamesmixin)
@@ -51,10 +51,10 @@ grafonnet.query.cloudWatch
   * [`fn withDimensions(value)`](#fn-cloudwatchmetricsquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchmetricsquerywithdimensionsmixin)
   * [`fn withExpression(value)`](#fn-cloudwatchmetricsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchmetricsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchmetricsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchmetricsquerywithid)
   * [`fn withLabel(value)`](#fn-cloudwatchmetricsquerywithlabel)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchmetricsquerywithmatchexact)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchmetricsquerywithmatchexact)
   * [`fn withMetricEditorMode(value)`](#fn-cloudwatchmetricsquerywithmetriceditormode)
   * [`fn withMetricName(value)`](#fn-cloudwatchmetricsquerywithmetricname)
   * [`fn withMetricQueryType(value)`](#fn-cloudwatchmetricsquerywithmetricquerytype)
@@ -193,7 +193,7 @@ A name/value pair that is part of the identity of a metric. For example, you can
 #### fn CloudWatchAnnotationQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -203,7 +203,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 #### fn CloudWatchAnnotationQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 Only show metrics that exactly match all defined dimension names.
@@ -235,7 +235,7 @@ The length of time associated with a specific Amazon CloudWatch statistic. Can b
 #### fn CloudWatchAnnotationQuery.withPrefixMatching
 
 ```ts
-withPrefixMatching(value)
+withPrefixMatching(value=true)
 ```
 
 Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
@@ -326,7 +326,7 @@ The CloudWatch Logs Insights query to execute
 #### fn CloudWatchLogsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -519,7 +519,7 @@ Math expression query
 #### fn CloudWatchMetricsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -545,7 +545,7 @@ Change the time series legend names using dynamic labels. See https://docs.aws.a
 #### fn CloudWatchMetricsQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 Only show metrics that exactly match all defined dimension names.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/elasticsearch.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/elasticsearch.md
@@ -8,7 +8,7 @@ grafonnet.query.elasticsearch
 * [`fn withBucketAggs(value)`](#fn-withbucketaggs)
 * [`fn withBucketAggsMixin(value)`](#fn-withbucketaggsmixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withMetrics(value)`](#fn-withmetrics)
 * [`fn withMetricsMixin(value)`](#fn-withmetricsmixin)
 * [`fn withQuery(value)`](#fn-withquery)
@@ -76,13 +76,13 @@ grafonnet.query.elasticsearch
       * [`fn withSize(value)`](#fn-bucketaggstermssettingswithsize)
 * [`obj metrics`](#obj-metrics)
   * [`obj Count`](#obj-metricscount)
-    * [`fn withHide(value)`](#fn-metricscountwithhide)
+    * [`fn withHide(value=true)`](#fn-metricscountwithhide)
     * [`fn withId(value)`](#fn-metricscountwithid)
     * [`fn withType(value)`](#fn-metricscountwithtype)
   * [`obj MetricAggregationWithSettings`](#obj-metricsmetricaggregationwithsettings)
     * [`obj Average`](#obj-metricsmetricaggregationwithsettingsaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettingsmixin)
@@ -94,7 +94,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsaveragesettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsaveragesettingsscriptwithinline)
     * [`obj BucketScript`](#obj-metricsmetricaggregationwithsettingsbucketscript)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariablesmixin)
@@ -111,7 +111,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricsmetricaggregationwithsettingscumulativesum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithsettings)
@@ -121,7 +121,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricsmetricaggregationwithsettingsderivative)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithsettings)
@@ -131,7 +131,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsderivativesettingswithunit)
     * [`obj ExtendedStats`](#obj-metricsmetricaggregationwithsettingsextendedstats)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithid)
       * [`fn withMeta(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmeta)
       * [`fn withMetaMixin(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmetamixin)
@@ -146,7 +146,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsextendedstatssettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatssettingsscriptwithinline)
     * [`obj Logs`](#obj-metricsmetricaggregationwithsettingslogs)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingslogswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettingsmixin)
@@ -155,7 +155,7 @@ grafonnet.query.elasticsearch
         * [`fn withLimit(value)`](#fn-metricsmetricaggregationwithsettingslogssettingswithlimit)
     * [`obj Max`](#obj-metricsmetricaggregationwithsettingsmax)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettingsmixin)
@@ -168,7 +168,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmaxsettingsscriptwithinline)
     * [`obj Min`](#obj-metricsmetricaggregationwithsettingsmin)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsminwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsminwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettingsmixin)
@@ -181,7 +181,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsminsettingsscriptwithinline)
     * [`obj MovingAverage`](#obj-metricsmetricaggregationwithsettingsmovingaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithsettings)
@@ -189,7 +189,7 @@ grafonnet.query.elasticsearch
       * [`fn withType(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithtype)
     * [`obj MovingFunction`](#obj-metricsmetricaggregationwithsettingsmovingfunction)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithsettings)
@@ -204,7 +204,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionsettingsscriptwithinline)
     * [`obj Percentiles`](#obj-metricsmetricaggregationwithsettingspercentiles)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettingsmixin)
@@ -219,7 +219,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingspercentilessettingsscriptwithinline)
     * [`obj Rate`](#obj-metricsmetricaggregationwithsettingsrate)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsratewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsratewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettingsmixin)
@@ -228,7 +228,7 @@ grafonnet.query.elasticsearch
         * [`fn withMode(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithmode)
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithunit)
     * [`obj RawData`](#obj-metricsmetricaggregationwithsettingsrawdata)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettingsmixin)
@@ -236,7 +236,7 @@ grafonnet.query.elasticsearch
       * [`obj settings`](#obj-metricsmetricaggregationwithsettingsrawdatasettings)
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdatasettingswithsize)
     * [`obj RawDocument`](#obj-metricsmetricaggregationwithsettingsrawdocument)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettingsmixin)
@@ -245,7 +245,7 @@ grafonnet.query.elasticsearch
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentsettingswithsize)
     * [`obj SerialDiff`](#obj-metricsmetricaggregationwithsettingsserialdiff)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithsettings)
@@ -255,7 +255,7 @@ grafonnet.query.elasticsearch
         * [`fn withLag(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffsettingswithlag)
     * [`obj Sum`](#obj-metricsmetricaggregationwithsettingssum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingssumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingssumwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettingsmixin)
@@ -267,7 +267,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingssumsettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingssumsettingsscriptwithinline)
     * [`obj TopMetrics`](#obj-metricsmetricaggregationwithsettingstopmetrics)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettingsmixin)
@@ -279,7 +279,7 @@ grafonnet.query.elasticsearch
         * [`fn withOrderBy(value)`](#fn-metricsmetricaggregationwithsettingstopmetricssettingswithorderby)
     * [`obj UniqueCount`](#obj-metricsmetricaggregationwithsettingsuniquecount)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettingsmixin)
@@ -289,7 +289,7 @@ grafonnet.query.elasticsearch
         * [`fn withPrecisionThreshold(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountsettingswithprecisionthreshold)
   * [`obj PipelineMetricAggregation`](#obj-metricspipelinemetricaggregation)
     * [`obj BucketScript`](#obj-metricspipelinemetricaggregationbucketscript)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariablesmixin)
@@ -306,7 +306,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricspipelinemetricaggregationbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricspipelinemetricaggregationcumulativesum)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithsettings)
@@ -316,7 +316,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricspipelinemetricaggregationcumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricspipelinemetricaggregationderivative)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationderivativewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationderivativewithsettings)
@@ -326,7 +326,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricspipelinemetricaggregationderivativesettingswithunit)
     * [`obj MovingAverage`](#obj-metricspipelinemetricaggregationmovingaverage)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithsettings)
@@ -373,7 +373,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -849,7 +849,7 @@ withSize(value)
 ##### fn metrics.Count.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -887,7 +887,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Average.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -968,7 +968,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1084,7 +1084,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1154,7 +1154,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1224,7 +1224,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.ExtendedStats.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1329,7 +1329,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.Logs.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1391,7 +1391,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Max.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1480,7 +1480,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Min.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1569,7 +1569,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1628,7 +1628,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingFunction.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1733,7 +1733,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Percentiles.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1838,7 +1838,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Rate.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1900,7 +1900,7 @@ withUnit(value)
 ###### fn metrics.MetricAggregationWithSettings.RawData.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1954,7 +1954,7 @@ withSize(value)
 ###### fn metrics.MetricAggregationWithSettings.RawDocument.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2016,7 +2016,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.SerialDiff.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2086,7 +2086,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Sum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2167,7 +2167,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.TopMetrics.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2253,7 +2253,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.UniqueCount.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2318,7 +2318,7 @@ withPrecisionThreshold(value)
 ###### fn metrics.PipelineMetricAggregation.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2434,7 +2434,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2504,7 +2504,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2574,7 +2574,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/grafanaPyroscope.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/grafanaPyroscope.md
@@ -7,7 +7,7 @@ grafonnet.query.grafanaPyroscope
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGroupBy(value)`](#fn-withgroupby)
 * [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withMaxNodes(value)`](#fn-withmaxnodes)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
@@ -46,7 +46,7 @@ Allows to group the results.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/loki.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/loki.md
@@ -8,12 +8,12 @@ grafonnet.query.loki
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
 * [`fn withExpr(value)`](#fn-withexpr)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withMaxLines(value)`](#fn-withmaxlines)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 * [`fn withResolution(value)`](#fn-withresolution)
 
@@ -56,7 +56,7 @@ The LogQL query.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -66,7 +66,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 @deprecated, now use queryType.
@@ -99,7 +99,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 @deprecated, now use queryType.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/parca.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/parca.md
@@ -5,7 +5,7 @@ grafonnet.query.parca
 ## Index
 
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -27,7 +27,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/prometheus.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/prometheus.md
@@ -7,15 +7,15 @@ grafonnet.query.prometheus
 * [`fn new(datasource, expr)`](#fn-new)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
-* [`fn withExemplar(value)`](#fn-withexemplar)
+* [`fn withExemplar(value=true)`](#fn-withexemplar)
 * [`fn withExpr(value)`](#fn-withexpr)
 * [`fn withFormat(value)`](#fn-withformat)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withIntervalFactor(value)`](#fn-withintervalfactor)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 
 ## Fields
@@ -49,7 +49,7 @@ Accepted values for `value` are "code", "builder"
 ### fn withExemplar
 
 ```ts
-withExemplar(value)
+withExemplar(value=true)
 ```
 
 Execute an additional query to identify interesting raw samples relevant for the given expr
@@ -75,7 +75,7 @@ Accepted values for `value` are "time_series", "table", "heatmap"
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -85,7 +85,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 Returns only the latest value that Prometheus has scraped for the requested time series
@@ -118,7 +118,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/tempo.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/tempo.md
@@ -8,7 +8,7 @@ grafonnet.query.tempo
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withFilters(value)`](#fn-withfilters)
 * [`fn withFiltersMixin(value)`](#fn-withfiltersmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLimit(value)`](#fn-withlimit)
 * [`fn withMaxDuration(value)`](#fn-withmaxduration)
 * [`fn withMinDuration(value)`](#fn-withminduration)
@@ -65,7 +65,7 @@ withFiltersMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/query/testData.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/query/testData.md
@@ -12,9 +12,9 @@ grafonnet.query.testData
 * [`fn withCsvWaveMixin(value)`](#fn-withcsvwavemixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withErrorType(value)`](#fn-witherrortype)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabels(value)`](#fn-withlabels)
-* [`fn withLevelColumn(value)`](#fn-withlevelcolumn)
+* [`fn withLevelColumn(value=true)`](#fn-withlevelcolumn)
 * [`fn withLines(value)`](#fn-withlines)
 * [`fn withNodes(value)`](#fn-withnodes)
 * [`fn withNodesMixin(value)`](#fn-withnodesmixin)
@@ -54,8 +54,8 @@ grafonnet.query.testData
   * [`fn withConfigMixin(value)`](#fn-simwithconfigmixin)
   * [`fn withKey(value)`](#fn-simwithkey)
   * [`fn withKeyMixin(value)`](#fn-simwithkeymixin)
-  * [`fn withLast(value)`](#fn-simwithlast)
-  * [`fn withStream(value)`](#fn-simwithstream)
+  * [`fn withLast(value=true)`](#fn-simwithlast)
+  * [`fn withStream(value=true)`](#fn-simwithstream)
   * [`obj key`](#obj-simkey)
     * [`fn withTick(value)`](#fn-simkeywithtick)
     * [`fn withType(value)`](#fn-simkeywithtype)
@@ -149,7 +149,7 @@ Accepted values for `value` are "server_panic", "frontend_exception", "frontend_
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -167,7 +167,7 @@ withLabels(value)
 ### fn withLevelColumn
 
 ```ts
-withLevelColumn(value)
+withLevelColumn(value=true)
 ```
 
 
@@ -474,7 +474,7 @@ withKeyMixin(value)
 #### fn sim.withLast
 
 ```ts
-withLast(value)
+withLast(value=true)
 ```
 
 
@@ -482,7 +482,7 @@ withLast(value)
 #### fn sim.withStream
 
 ```ts
-withStream(value)
+withStream(value=true)
 ```
 
 

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/serviceaccount.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/serviceaccount.md
@@ -8,7 +8,7 @@ grafonnet.serviceaccount
 * [`fn withAccessControlMixin(value)`](#fn-withaccesscontrolmixin)
 * [`fn withAvatarUrl(value)`](#fn-withavatarurl)
 * [`fn withId(value)`](#fn-withid)
-* [`fn withIsDisabled(value)`](#fn-withisdisabled)
+* [`fn withIsDisabled(value=true)`](#fn-withisdisabled)
 * [`fn withLogin(value)`](#fn-withlogin)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withOrgId(value)`](#fn-withorgid)
@@ -55,7 +55,7 @@ ID is the unique identifier of the service account in the database.
 ### fn withIsDisabled
 
 ```ts
-withIsDisabled(value)
+withIsDisabled(value=true)
 ```
 
 IsDisabled indicates if the service account is disabled.

--- a/gen/grafonnet-v10.0.0/docs/grafonnet/util.md
+++ b/gen/grafonnet-v10.0.0/docs/grafonnet/util.md
@@ -7,7 +7,8 @@ Helper functions that work well with Grafonnet.
 * [`obj dashboard`](#obj-dashboard)
   * [`fn getOptionsForCustomQuery(query)`](#fn-dashboardgetoptionsforcustomquery)
 * [`obj grid`](#obj-grid)
-  * [`fn makeGrid(panels, panelWidth, panelHeight)`](#fn-gridmakegrid)
+  * [`fn makeGrid(panels, panelWidth, panelHeight, startY)`](#fn-gridmakegrid)
+  * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
 * [`obj string`](#obj-string)
@@ -40,7 +41,7 @@ compatible solution.
 #### fn grid.makeGrid
 
 ```ts
-makeGrid(panels, panelWidth, panelHeight)
+makeGrid(panels, panelWidth, panelHeight, startY)
 ```
 
 `makeGrid` returns an array of `panels` organized in a grid with equal `panelWidth`
@@ -50,6 +51,18 @@ then all panels below it will be folded into the row.
 This function will use the full grid of 24 columns, setting `panelWidth` to a value
 that can divide 24 into equal parts will fill up the page nicely. (1, 2, 3, 4, 6, 8, 12)
 Other value for `panelWidth` will leave a gap on the far right.
+
+Optional `startY` can be provided to place generated grid above or below existing panels.
+
+
+#### fn grid.wrapPanels
+
+```ts
+wrapPanels(panels, panelWidth, panelHeight, startY)
+```
+
+`wrapPanels` returns an array of `panels` organized in a grid, wrapping up to next 'row' if total width exceeds full grid of 24 columns.
+'panelHeight' and 'panelWidth' are used unless panels already have height and width defined.
 
 
 ### obj panel

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/annotation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/annotation.md
@@ -8,7 +8,7 @@
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withEnable(value=true)`](#fn-withenable)
-* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withIconColor(value)`](#fn-withiconcolor)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withRawQuery(value)`](#fn-withrawquery)
@@ -21,7 +21,7 @@
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj target`](#obj-target)
   * [`fn withLimit(value)`](#fn-targetwithlimit)
-  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withMatchAny(value=true)`](#fn-targetwithmatchany)
   * [`fn withTags(value)`](#fn-targetwithtags)
   * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
   * [`fn withType(value)`](#fn-targetwithtype)
@@ -63,7 +63,7 @@ Whether annotation is enabled.
 ### fn withHide
 
 ```ts
-withHide(value=false)
+withHide(value=true)
 ```
 
 Whether to hide annotation.
@@ -157,7 +157,7 @@ withLimit(value)
 #### fn target.withMatchAny
 
 ```ts
-withMatchAny(value)
+withMatchAny(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/index.md
@@ -18,7 +18,7 @@ grafonnet.dashboard
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
-* [`fn withLiveNow(value)`](#fn-withlivenow)
+* [`fn withLiveNow(value=true)`](#fn-withlivenow)
 * [`fn withPanels(value)`](#fn-withpanels)
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
@@ -42,9 +42,9 @@ grafonnet.dashboard
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
 * [`obj timepicker`](#obj-timepicker)
-  * [`fn withCollapse(value=false)`](#fn-timepickerwithcollapse)
+  * [`fn withCollapse(value=true)`](#fn-timepickerwithcollapse)
   * [`fn withEnable(value=true)`](#fn-timepickerwithenable)
-  * [`fn withHidden(value=false)`](#fn-timepickerwithhidden)
+  * [`fn withHidden(value=true)`](#fn-timepickerwithhidden)
   * [`fn withRefreshIntervals(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervals)
   * [`fn withRefreshIntervalsMixin(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervalsmixin)
   * [`fn withTimeOptions(value=["5m","15m","1h","6h","12h","24h","2d","7d","30d"])`](#fn-timepickerwithtimeoptions)
@@ -159,7 +159,7 @@ g.dashboard.new('Title dashboard')
 ### fn withLiveNow
 
 ```ts
-withLiveNow(value)
+withLiveNow(value=true)
 ```
 
 When set to true, the dashboard will redraw panels at an interval matching the pixel width.
@@ -346,7 +346,7 @@ withTo(value="now")
 #### fn timepicker.withCollapse
 
 ```ts
-withCollapse(value=false)
+withCollapse(value=true)
 ```
 
 Whether timepicker is collapsed or not.
@@ -362,7 +362,7 @@ Whether timepicker is enabled or not.
 #### fn timepicker.withHidden
 
 ```ts
-withHidden(value=false)
+withHidden(value=true)
 ```
 
 Whether timepicker is visible or not.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/link.md
@@ -22,19 +22,19 @@ g.dashboard.new('Title dashboard')
 * [`obj dashboards`](#obj-dashboards)
   * [`fn new(title, tags)`](#fn-dashboardsnew)
   * [`obj options`](#obj-dashboardsoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-dashboardsoptionswithtargetblank)
 * [`obj link`](#obj-link)
   * [`fn new(title, url)`](#fn-linknew)
   * [`fn withIcon(value)`](#fn-linkwithicon)
   * [`fn withTooltip(value)`](#fn-linkwithtooltip)
   * [`obj options`](#obj-linkoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-linkoptionswithtargetblank)
 
 ## Fields
 
@@ -56,7 +56,7 @@ Create links to dashboards based on `tags`.
 ##### fn dashboards.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -64,7 +64,7 @@ withAsDropdown(value=false)
 ##### fn dashboards.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -72,7 +72,7 @@ withIncludeVars(value=false)
 ##### fn dashboards.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -80,7 +80,7 @@ withKeepTime(value=false)
 ##### fn dashboards.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 
@@ -119,7 +119,7 @@ withTooltip(value)
 ##### fn link.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -127,7 +127,7 @@ withAsDropdown(value=false)
 ##### fn link.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -135,7 +135,7 @@ withIncludeVars(value=false)
 ##### fn link.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -143,7 +143,7 @@ withKeepTime(value=false)
 ##### fn link.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/variable.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/dashboard/variable.md
@@ -113,7 +113,7 @@ g.dashboard.new('my dashboard')
       * [`fn withNothing()`](#fn-querygeneraloptionsshowondashboardwithnothing)
       * [`fn withValueOnly()`](#fn-querygeneraloptionsshowondashboardwithvalueonly)
   * [`obj queryTypes`](#obj-queryquerytypes)
-    * [`fn withLabelValues(label, metric)`](#fn-queryquerytypeswithlabelvalues)
+    * [`fn withLabelValues(label, metric="")`](#fn-queryquerytypeswithlabelvalues)
   * [`obj refresh`](#obj-queryrefresh)
     * [`fn onLoad()`](#fn-queryrefreshonload)
     * [`fn onTime()`](#fn-queryrefreshontime)
@@ -668,7 +668,7 @@ withValueOnly()
 ##### fn query.queryTypes.withLabelValues
 
 ```ts
-withLabelValues(label, metric)
+withLabelValues(label, metric="")
 ```
 
 Construct a Prometheus template variable using `label_values()`.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,7 +27,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withAlertmanager(value)`](#fn-optionswithalertmanager)
-  * [`fn withExpandAll(value)`](#fn-optionswithexpandall)
+  * [`fn withExpandAll(value=true)`](#fn-optionswithexpandall)
   * [`fn withLabels(value)`](#fn-optionswithlabels)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -36,7 +36,7 @@ grafonnet.panel.alertGroups
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -113,7 +113,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -175,7 +175,7 @@ Name of the alertmanager used as a source for alerts
 #### fn options.withExpandAll
 
 ```ts
-withExpandAll(value)
+withExpandAll(value=true)
 ```
 
 Expand all alert groups by default
@@ -248,7 +248,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/alertGroups/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.annotationsList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,8 +30,8 @@ grafonnet.panel.annotationsList
   * [`fn withNavigateAfter(value="10m")`](#fn-optionswithnavigateafter)
   * [`fn withNavigateBefore(value="10m")`](#fn-optionswithnavigatebefore)
   * [`fn withNavigateToPanel(value=true)`](#fn-optionswithnavigatetopanel)
-  * [`fn withOnlyFromThisDashboard(value=false)`](#fn-optionswithonlyfromthisdashboard)
-  * [`fn withOnlyInTimeRange(value=false)`](#fn-optionswithonlyintimerange)
+  * [`fn withOnlyFromThisDashboard(value=true)`](#fn-optionswithonlyfromthisdashboard)
+  * [`fn withOnlyInTimeRange(value=true)`](#fn-optionswithonlyintimerange)
   * [`fn withShowTags(value=true)`](#fn-optionswithshowtags)
   * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withShowUser(value=true)`](#fn-optionswithshowuser)
@@ -44,7 +44,7 @@ grafonnet.panel.annotationsList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -207,7 +207,7 @@ withNavigateToPanel(value=true)
 #### fn options.withOnlyFromThisDashboard
 
 ```ts
-withOnlyFromThisDashboard(value=false)
+withOnlyFromThisDashboard(value=true)
 ```
 
 
@@ -215,7 +215,7 @@ withOnlyFromThisDashboard(value=false)
 #### fn options.withOnlyInTimeRange
 
 ```ts
-withOnlyInTimeRange(value=false)
+withOnlyInTimeRange(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/annotationsList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.barChart
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -37,9 +37,9 @@ grafonnet.panel.barChart
       * [`fn withThresholdsStyle(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstyle)
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
@@ -48,7 +48,7 @@ grafonnet.panel.barChart
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -59,7 +59,7 @@ grafonnet.panel.barChart
   * [`fn withBarRadius(value=0)`](#fn-optionswithbarradius)
   * [`fn withBarWidth(value=0.97)`](#fn-optionswithbarwidth)
   * [`fn withColorByField(value)`](#fn-optionswithcolorbyfield)
-  * [`fn withFullHighlight(value=false)`](#fn-optionswithfullhighlight)
+  * [`fn withFullHighlight(value=true)`](#fn-optionswithfullhighlight)
   * [`fn withGroupWidth(value=0.7)`](#fn-optionswithgroupwidth)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
@@ -75,15 +75,15 @@ grafonnet.panel.barChart
   * [`fn withXTickLabelRotation(value=0)`](#fn-optionswithxticklabelrotation)
   * [`fn withXTickLabelSpacing(value=0)`](#fn-optionswithxticklabelspacing)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
@@ -98,7 +98,7 @@ grafonnet.panel.barChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -318,7 +318,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -326,7 +326,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -334,7 +334,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -395,7 +395,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -473,7 +473,7 @@ Use the color value for a sibling field to color each bar value.
 #### fn options.withFullHighlight
 
 ```ts
-withFullHighlight(value=false)
+withFullHighlight(value=true)
 ```
 
 Enables mode which highlights the entire bar area and shows tooltip when cursor
@@ -604,7 +604,7 @@ negative values indicate backwards skipping behavior
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -639,7 +639,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -657,7 +657,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -673,7 +673,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -788,7 +788,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.barGauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.barGauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -52,7 +52,7 @@ grafonnet.panel.barGauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -129,7 +129,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -305,7 +305,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -389,7 +389,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/barGauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.candlestick
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.candlestick
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/candlestick/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.canvas
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.canvas
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/canvas/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,8 +31,8 @@ grafonnet.panel.dashboardList
   * [`fn withMaxItems(value=10)`](#fn-optionswithmaxitems)
   * [`fn withQuery(value="")`](#fn-optionswithquery)
   * [`fn withShowHeadings(value=true)`](#fn-optionswithshowheadings)
-  * [`fn withShowRecentlyViewed(value=false)`](#fn-optionswithshowrecentlyviewed)
-  * [`fn withShowSearch(value=false)`](#fn-optionswithshowsearch)
+  * [`fn withShowRecentlyViewed(value=true)`](#fn-optionswithshowrecentlyviewed)
+  * [`fn withShowSearch(value=true)`](#fn-optionswithshowsearch)
   * [`fn withShowStarred(value=true)`](#fn-optionswithshowstarred)
   * [`fn withTags(value)`](#fn-optionswithtags)
   * [`fn withTagsMixin(value)`](#fn-optionswithtagsmixin)
@@ -43,7 +43,7 @@ grafonnet.panel.dashboardList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -120,7 +120,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -216,7 +216,7 @@ withShowHeadings(value=true)
 #### fn options.withShowRecentlyViewed
 
 ```ts
-withShowRecentlyViewed(value=false)
+withShowRecentlyViewed(value=true)
 ```
 
 
@@ -224,7 +224,7 @@ withShowRecentlyViewed(value=false)
 #### fn options.withShowSearch
 
 ```ts
-withShowSearch(value=false)
+withShowSearch(value=true)
 ```
 
 
@@ -313,7 +313,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/dashboardList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.debug
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,9 +30,9 @@ grafonnet.panel.debug
   * [`fn withCountersMixin(value)`](#fn-optionswithcountersmixin)
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj counters`](#obj-optionscounters)
-    * [`fn withDataChanged(value)`](#fn-optionscounterswithdatachanged)
-    * [`fn withRender(value)`](#fn-optionscounterswithrender)
-    * [`fn withSchemaChanged(value)`](#fn-optionscounterswithschemachanged)
+    * [`fn withDataChanged(value=true)`](#fn-optionscounterswithdatachanged)
+    * [`fn withRender(value=true)`](#fn-optionscounterswithrender)
+    * [`fn withSchemaChanged(value=true)`](#fn-optionscounterswithschemachanged)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -40,7 +40,7 @@ grafonnet.panel.debug
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -117,7 +117,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -200,7 +200,7 @@ Accepted values for `value` are "render", "events", "cursor", "State", "ThrowErr
 ##### fn options.counters.withDataChanged
 
 ```ts
-withDataChanged(value)
+withDataChanged(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ withDataChanged(value)
 ##### fn options.counters.withRender
 
 ```ts
-withRender(value)
+withRender(value=true)
 ```
 
 
@@ -216,7 +216,7 @@ withRender(value)
 ##### fn options.counters.withSchemaChanged
 
 ```ts
-withSchemaChanged(value)
+withSchemaChanged(value=true)
 ```
 
 
@@ -281,7 +281,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/debug/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.gauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -29,7 +29,7 @@ grafonnet.panel.gauge
   * [`fn withOrientation(value)`](#fn-optionswithorientation)
   * [`fn withReduceOptions(value)`](#fn-optionswithreduceoptions)
   * [`fn withReduceOptionsMixin(value)`](#fn-optionswithreduceoptionsmixin)
-  * [`fn withShowThresholdLabels(value=false)`](#fn-optionswithshowthresholdlabels)
+  * [`fn withShowThresholdLabels(value=true)`](#fn-optionswithshowthresholdlabels)
   * [`fn withShowThresholdMarkers(value=true)`](#fn-optionswithshowthresholdmarkers)
   * [`fn withText(value)`](#fn-optionswithtext)
   * [`fn withTextMixin(value)`](#fn-optionswithtextmixin)
@@ -38,7 +38,7 @@ grafonnet.panel.gauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -49,7 +49,7 @@ grafonnet.panel.gauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -126,7 +126,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -206,7 +206,7 @@ TODO docs
 #### fn options.withShowThresholdLabels
 
 ```ts
-withShowThresholdLabels(value=false)
+withShowThresholdLabels(value=true)
 ```
 
 
@@ -273,7 +273,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -357,7 +357,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/gauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.geomap
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -43,7 +43,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionsbasemapwithlocationmixin)
     * [`fn withName(value)`](#fn-optionsbasemapwithname)
     * [`fn withOpacity(value)`](#fn-optionsbasemapwithopacity)
-    * [`fn withTooltip(value)`](#fn-optionsbasemapwithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionsbasemapwithtooltip)
     * [`fn withType(value)`](#fn-optionsbasemapwithtype)
     * [`obj location`](#obj-optionsbasemaplocation)
       * [`fn withGazetteer(value)`](#fn-optionsbasemaplocationwithgazetteer)
@@ -54,12 +54,12 @@ grafonnet.panel.geomap
       * [`fn withMode(value)`](#fn-optionsbasemaplocationwithmode)
       * [`fn withWkt(value)`](#fn-optionsbasemaplocationwithwkt)
   * [`obj controls`](#obj-optionscontrols)
-    * [`fn withMouseWheelZoom(value)`](#fn-optionscontrolswithmousewheelzoom)
-    * [`fn withShowAttribution(value)`](#fn-optionscontrolswithshowattribution)
-    * [`fn withShowDebug(value)`](#fn-optionscontrolswithshowdebug)
-    * [`fn withShowMeasure(value)`](#fn-optionscontrolswithshowmeasure)
-    * [`fn withShowScale(value)`](#fn-optionscontrolswithshowscale)
-    * [`fn withShowZoom(value)`](#fn-optionscontrolswithshowzoom)
+    * [`fn withMouseWheelZoom(value=true)`](#fn-optionscontrolswithmousewheelzoom)
+    * [`fn withShowAttribution(value=true)`](#fn-optionscontrolswithshowattribution)
+    * [`fn withShowDebug(value=true)`](#fn-optionscontrolswithshowdebug)
+    * [`fn withShowMeasure(value=true)`](#fn-optionscontrolswithshowmeasure)
+    * [`fn withShowScale(value=true)`](#fn-optionscontrolswithshowscale)
+    * [`fn withShowZoom(value=true)`](#fn-optionscontrolswithshowzoom)
   * [`obj layers`](#obj-optionslayers)
     * [`fn withConfig(value)`](#fn-optionslayerswithconfig)
     * [`fn withFilterData(value)`](#fn-optionslayerswithfilterdata)
@@ -67,7 +67,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionslayerswithlocationmixin)
     * [`fn withName(value)`](#fn-optionslayerswithname)
     * [`fn withOpacity(value)`](#fn-optionslayerswithopacity)
-    * [`fn withTooltip(value)`](#fn-optionslayerswithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionslayerswithtooltip)
     * [`fn withType(value)`](#fn-optionslayerswithtype)
     * [`obj location`](#obj-optionslayerslocation)
       * [`fn withGazetteer(value)`](#fn-optionslayerslocationwithgazetteer)
@@ -82,14 +82,14 @@ grafonnet.panel.geomap
   * [`obj view`](#obj-optionsview)
     * [`fn withAllLayers(value=true)`](#fn-optionsviewwithalllayers)
     * [`fn withId(value="zero")`](#fn-optionsviewwithid)
-    * [`fn withLastOnly(value)`](#fn-optionsviewwithlastonly)
+    * [`fn withLastOnly(value=true)`](#fn-optionsviewwithlastonly)
     * [`fn withLat(value=0)`](#fn-optionsviewwithlat)
     * [`fn withLayer(value)`](#fn-optionsviewwithlayer)
     * [`fn withLon(value=0)`](#fn-optionsviewwithlon)
     * [`fn withMaxZoom(value)`](#fn-optionsviewwithmaxzoom)
     * [`fn withMinZoom(value)`](#fn-optionsviewwithminzoom)
     * [`fn withPadding(value)`](#fn-optionsviewwithpadding)
-    * [`fn withShared(value)`](#fn-optionsviewwithshared)
+    * [`fn withShared(value=true)`](#fn-optionsviewwithshared)
     * [`fn withZoom(value=1)`](#fn-optionsviewwithzoom)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -98,7 +98,7 @@ grafonnet.panel.geomap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -175,7 +175,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -362,7 +362,7 @@ Layer opacity (0-1)
 ##### fn options.basemap.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -442,7 +442,7 @@ withWkt(value)
 ##### fn options.controls.withMouseWheelZoom
 
 ```ts
-withMouseWheelZoom(value)
+withMouseWheelZoom(value=true)
 ```
 
 let the mouse wheel zoom
@@ -450,7 +450,7 @@ let the mouse wheel zoom
 ##### fn options.controls.withShowAttribution
 
 ```ts
-withShowAttribution(value)
+withShowAttribution(value=true)
 ```
 
 Lower right
@@ -458,7 +458,7 @@ Lower right
 ##### fn options.controls.withShowDebug
 
 ```ts
-withShowDebug(value)
+withShowDebug(value=true)
 ```
 
 Show debug
@@ -466,7 +466,7 @@ Show debug
 ##### fn options.controls.withShowMeasure
 
 ```ts
-withShowMeasure(value)
+withShowMeasure(value=true)
 ```
 
 Show measure
@@ -474,7 +474,7 @@ Show measure
 ##### fn options.controls.withShowScale
 
 ```ts
-withShowScale(value)
+withShowScale(value=true)
 ```
 
 Scale options
@@ -482,7 +482,7 @@ Scale options
 ##### fn options.controls.withShowZoom
 
 ```ts
-withShowZoom(value)
+withShowZoom(value=true)
 ```
 
 Zoom (upper left)
@@ -543,7 +543,7 @@ Layer opacity (0-1)
 ##### fn options.layers.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -652,7 +652,7 @@ withId(value="zero")
 ##### fn options.view.withLastOnly
 
 ```ts
-withLastOnly(value)
+withLastOnly(value=true)
 ```
 
 
@@ -708,7 +708,7 @@ withPadding(value)
 ##### fn options.view.withShared
 
 ```ts
-withShared(value)
+withShared(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/geomap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/index.md
@@ -24,16 +24,16 @@ grafonnet.panel.heatmap
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.heatmap
   * [`fn withName(value)`](#fn-librarypanelwithname)
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
-  * [`fn withCalculate(value=false)`](#fn-optionswithcalculate)
+  * [`fn withCalculate(value=true)`](#fn-optionswithcalculate)
   * [`fn withCalculation(value)`](#fn-optionswithcalculation)
   * [`fn withCalculationMixin(value)`](#fn-optionswithcalculationmixin)
   * [`fn withCellGap(value=1)`](#fn-optionswithcellgap)
@@ -101,7 +101,7 @@ grafonnet.panel.heatmap
       * [`fn withMax(value)`](#fn-optionscolorheatmapcoloroptionswithmax)
       * [`fn withMin(value)`](#fn-optionscolorheatmapcoloroptionswithmin)
       * [`fn withMode(value)`](#fn-optionscolorheatmapcoloroptionswithmode)
-      * [`fn withReverse(value)`](#fn-optionscolorheatmapcoloroptionswithreverse)
+      * [`fn withReverse(value=true)`](#fn-optionscolorheatmapcoloroptionswithreverse)
       * [`fn withScale(value)`](#fn-optionscolorheatmapcoloroptionswithscale)
       * [`fn withScheme(value)`](#fn-optionscolorheatmapcoloroptionswithscheme)
       * [`fn withSteps(value)`](#fn-optionscolorheatmapcoloroptionswithsteps)
@@ -114,17 +114,17 @@ grafonnet.panel.heatmap
       * [`fn withGe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithge)
       * [`fn withLe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithle)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withShow(value)`](#fn-optionslegendwithshow)
+    * [`fn withShow(value=true)`](#fn-optionslegendwithshow)
   * [`obj rowsFrame`](#obj-optionsrowsframe)
     * [`fn withLayout(value)`](#fn-optionsrowsframewithlayout)
     * [`fn withValue(value)`](#fn-optionsrowsframewithvalue)
   * [`obj tooltip`](#obj-optionstooltip)
-    * [`fn withShow(value)`](#fn-optionstooltipwithshow)
-    * [`fn withYHistogram(value)`](#fn-optionstooltipwithyhistogram)
+    * [`fn withShow(value=true)`](#fn-optionstooltipwithshow)
+    * [`fn withYHistogram(value=true)`](#fn-optionstooltipwithyhistogram)
   * [`obj yAxis`](#obj-optionsyaxis)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsyaxiswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsyaxiswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsyaxiswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsyaxiswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsyaxiswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsyaxiswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsyaxiswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsyaxiswithaxissoftmax)
@@ -133,7 +133,7 @@ grafonnet.panel.heatmap
     * [`fn withDecimals(value)`](#fn-optionsyaxiswithdecimals)
     * [`fn withMax(value)`](#fn-optionsyaxiswithmax)
     * [`fn withMin(value)`](#fn-optionsyaxiswithmin)
-    * [`fn withReverse(value)`](#fn-optionsyaxiswithreverse)
+    * [`fn withReverse(value=true)`](#fn-optionsyaxiswithreverse)
     * [`fn withScaleDistribution(value)`](#fn-optionsyaxiswithscaledistribution)
     * [`fn withScaleDistributionMixin(value)`](#fn-optionsyaxiswithscaledistributionmixin)
     * [`fn withUnit(value)`](#fn-optionsyaxiswithunit)
@@ -148,7 +148,7 @@ grafonnet.panel.heatmap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -258,7 +258,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -266,7 +266,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -274,7 +274,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -322,7 +322,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -376,7 +376,7 @@ withUid(value)
 #### fn options.withCalculate
 
 ```ts
-withCalculate(value=false)
+withCalculate(value=true)
 ```
 
 Controls if the heatmap should be calculated from data
@@ -823,7 +823,7 @@ Accepted values for `value` are "opacity", "scheme"
 ###### fn options.color.HeatmapColorOptions.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the color scheme
@@ -909,7 +909,7 @@ Sets the filter range to values less than or equal to the given value
 ##### fn options.legend.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the legend is shown
@@ -941,7 +941,7 @@ Sets the name of the cell when not calculating from data
 ##### fn options.tooltip.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the tooltip is shown
@@ -949,7 +949,7 @@ Controls if the tooltip is shown
 ##### fn options.tooltip.withYHistogram
 
 ```ts
-withYHistogram(value)
+withYHistogram(value=true)
 ```
 
 Controls if the tooltip shows a histogram of the y-axis values
@@ -960,7 +960,7 @@ Controls if the tooltip shows a histogram of the y-axis values
 ##### fn options.yAxis.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -978,7 +978,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.yAxis.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -1052,7 +1052,7 @@ Sets the minimum value for the yAxis
 ##### fn options.yAxis.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the yAxis
@@ -1170,7 +1170,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/heatmap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.histogram
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -35,16 +35,16 @@ grafonnet.panel.histogram
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -54,21 +54,21 @@ grafonnet.panel.histogram
 * [`obj options`](#obj-options)
   * [`fn withBucketOffset(value=0)`](#fn-optionswithbucketoffset)
   * [`fn withBucketSize(value)`](#fn-optionswithbucketsize)
-  * [`fn withCombine(value)`](#fn-optionswithcombine)
+  * [`fn withCombine(value=true)`](#fn-optionswithcombine)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -80,7 +80,7 @@ grafonnet.panel.histogram
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -155,7 +155,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -173,7 +173,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -284,7 +284,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -300,7 +300,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -348,7 +348,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -418,7 +418,7 @@ Size of each bucket
 #### fn options.withCombine
 
 ```ts
-withCombine(value)
+withCombine(value=true)
 ```
 
 Combines multiple series into a single histogram
@@ -461,7 +461,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -496,7 +496,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -514,7 +514,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -530,7 +530,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -626,7 +626,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/histogram/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withDedupStrategy(value)`](#fn-optionswithdedupstrategy)
-  * [`fn withEnableLogDetails(value)`](#fn-optionswithenablelogdetails)
-  * [`fn withPrettifyLogMessage(value)`](#fn-optionswithprettifylogmessage)
-  * [`fn withShowCommonLabels(value)`](#fn-optionswithshowcommonlabels)
-  * [`fn withShowLabels(value)`](#fn-optionswithshowlabels)
-  * [`fn withShowTime(value)`](#fn-optionswithshowtime)
+  * [`fn withEnableLogDetails(value=true)`](#fn-optionswithenablelogdetails)
+  * [`fn withPrettifyLogMessage(value=true)`](#fn-optionswithprettifylogmessage)
+  * [`fn withShowCommonLabels(value=true)`](#fn-optionswithshowcommonlabels)
+  * [`fn withShowLabels(value=true)`](#fn-optionswithshowlabels)
+  * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withSortOrder(value)`](#fn-optionswithsortorder)
-  * [`fn withWrapLogMessage(value)`](#fn-optionswithwraplogmessage)
+  * [`fn withWrapLogMessage(value=true)`](#fn-optionswithwraplogmessage)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.logs
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -182,7 +182,7 @@ Accepted values for `value` are "none", "exact", "numbers", "signature"
 #### fn options.withEnableLogDetails
 
 ```ts
-withEnableLogDetails(value)
+withEnableLogDetails(value=true)
 ```
 
 
@@ -190,7 +190,7 @@ withEnableLogDetails(value)
 #### fn options.withPrettifyLogMessage
 
 ```ts
-withPrettifyLogMessage(value)
+withPrettifyLogMessage(value=true)
 ```
 
 
@@ -198,7 +198,7 @@ withPrettifyLogMessage(value)
 #### fn options.withShowCommonLabels
 
 ```ts
-withShowCommonLabels(value)
+withShowCommonLabels(value=true)
 ```
 
 
@@ -206,7 +206,7 @@ withShowCommonLabels(value)
 #### fn options.withShowLabels
 
 ```ts
-withShowLabels(value)
+withShowLabels(value=true)
 ```
 
 
@@ -214,7 +214,7 @@ withShowLabels(value)
 #### fn options.withShowTime
 
 ```ts
-withShowTime(value)
+withShowTime(value=true)
 ```
 
 
@@ -232,7 +232,7 @@ Accepted values for `value` are "Descending", "Ascending"
 #### fn options.withWrapLogMessage
 
 ```ts
-withWrapLogMessage(value)
+withWrapLogMessage(value=true)
 ```
 
 
@@ -297,7 +297,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/logs/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.news
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -35,7 +35,7 @@ grafonnet.panel.news
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -112,7 +112,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -239,7 +239,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/news/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.nodeGraph
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,7 +48,7 @@ grafonnet.panel.nodeGraph
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -125,7 +125,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/nodeGraph/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/index.md
@@ -22,12 +22,12 @@ grafonnet.panel.pieChart
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.pieChart
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withValues(value)`](#fn-optionslegendwithvalues)
     * [`fn withValuesMixin(value)`](#fn-optionslegendwithvaluesmixin)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
@@ -65,7 +65,7 @@ grafonnet.panel.pieChart
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -79,7 +79,7 @@ grafonnet.panel.pieChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -181,7 +181,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -189,7 +189,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -365,7 +365,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -400,7 +400,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -418,7 +418,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -434,7 +434,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -501,7 +501,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -608,7 +608,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/pieChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/row.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/row.md
@@ -5,7 +5,7 @@ grafonnet.panel.row
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withCollapsed(value=false)`](#fn-withcollapsed)
+* [`fn withCollapsed(value=true)`](#fn-withcollapsed)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withGridPos(value)`](#fn-withgridpos)
@@ -21,7 +21,7 @@ grafonnet.panel.row
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -39,7 +39,7 @@ Creates a new row panel with a title.
 ### fn withCollapsed
 
 ```ts
-withCollapsed(value=false)
+withCollapsed(value=true)
 ```
 
 
@@ -157,7 +157,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.stat
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -40,7 +40,7 @@ grafonnet.panel.stat
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -51,7 +51,7 @@ grafonnet.panel.stat
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -128,7 +128,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -299,7 +299,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -383,7 +383,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stat/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.stateTimeline
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=0)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.stateTimeline
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -68,7 +68,7 @@ grafonnet.panel.stateTimeline
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -178,7 +178,7 @@ withLineWidth(value=0)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -186,7 +186,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -194,7 +194,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -213,7 +213,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -354,7 +354,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -389,7 +389,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -407,7 +407,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -423,7 +423,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -519,7 +519,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/stateTimeline/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.statusHistory
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=1)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -47,15 +47,15 @@ grafonnet.panel.statusHistory
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -67,7 +67,7 @@ grafonnet.panel.statusHistory
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -177,7 +177,7 @@ withLineWidth(value=1)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -185,7 +185,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -193,7 +193,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -212,7 +212,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -343,7 +343,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -378,7 +378,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -396,7 +396,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -412,7 +412,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -508,7 +508,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/statusHistory/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.table
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,23 +31,23 @@ grafonnet.panel.table
   * [`fn withFooterMixin(value={"countRows": false,"reducer": [],"show": false})`](#fn-optionswithfootermixin)
   * [`fn withFrameIndex(value=0)`](#fn-optionswithframeindex)
   * [`fn withShowHeader(value=true)`](#fn-optionswithshowheader)
-  * [`fn withShowRowNums(value=false)`](#fn-optionswithshowrownums)
-  * [`fn withShowTypeIcons(value=false)`](#fn-optionswithshowtypeicons)
+  * [`fn withShowRowNums(value=true)`](#fn-optionswithshowrownums)
+  * [`fn withShowTypeIcons(value=true)`](#fn-optionswithshowtypeicons)
   * [`fn withSortBy(value)`](#fn-optionswithsortby)
   * [`fn withSortByMixin(value)`](#fn-optionswithsortbymixin)
   * [`obj footer`](#obj-optionsfooter)
     * [`fn withTableFooterOptions(value)`](#fn-optionsfooterwithtablefooteroptions)
     * [`fn withTableFooterOptionsMixin(value)`](#fn-optionsfooterwithtablefooteroptionsmixin)
     * [`obj TableFooterOptions`](#obj-optionsfootertablefooteroptions)
-      * [`fn withCountRows(value)`](#fn-optionsfootertablefooteroptionswithcountrows)
-      * [`fn withEnablePagination(value)`](#fn-optionsfootertablefooteroptionswithenablepagination)
+      * [`fn withCountRows(value=true)`](#fn-optionsfootertablefooteroptionswithcountrows)
+      * [`fn withEnablePagination(value=true)`](#fn-optionsfootertablefooteroptionswithenablepagination)
       * [`fn withFields(value)`](#fn-optionsfootertablefooteroptionswithfields)
       * [`fn withFieldsMixin(value)`](#fn-optionsfootertablefooteroptionswithfieldsmixin)
       * [`fn withReducer(value)`](#fn-optionsfootertablefooteroptionswithreducer)
       * [`fn withReducerMixin(value)`](#fn-optionsfootertablefooteroptionswithreducermixin)
-      * [`fn withShow(value)`](#fn-optionsfootertablefooteroptionswithshow)
+      * [`fn withShow(value=true)`](#fn-optionsfootertablefooteroptionswithshow)
   * [`obj sortBy`](#obj-optionssortby)
-    * [`fn withDesc(value)`](#fn-optionssortbywithdesc)
+    * [`fn withDesc(value=true)`](#fn-optionssortbywithdesc)
     * [`fn withDisplayName(value)`](#fn-optionssortbywithdisplayname)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -56,7 +56,7 @@ grafonnet.panel.table
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -133,7 +133,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -229,7 +229,7 @@ Controls whether the panel should show the header
 #### fn options.withShowRowNums
 
 ```ts
-withShowRowNums(value=false)
+withShowRowNums(value=true)
 ```
 
 Controls whether the columns should be numbered
@@ -237,7 +237,7 @@ Controls whether the columns should be numbered
 #### fn options.withShowTypeIcons
 
 ```ts
-withShowTypeIcons(value=false)
+withShowTypeIcons(value=true)
 ```
 
 Controls whether the header should show icons for the column types
@@ -283,7 +283,7 @@ Footer options
 ###### fn options.footer.TableFooterOptions.withCountRows
 
 ```ts
-withCountRows(value)
+withCountRows(value=true)
 ```
 
 
@@ -291,7 +291,7 @@ withCountRows(value)
 ###### fn options.footer.TableFooterOptions.withEnablePagination
 
 ```ts
-withEnablePagination(value)
+withEnablePagination(value=true)
 ```
 
 
@@ -331,7 +331,7 @@ withReducerMixin(value)
 ###### fn options.footer.TableFooterOptions.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 
@@ -342,7 +342,7 @@ withShow(value)
 ##### fn options.sortBy.withDesc
 
 ```ts
-withDesc(value)
+withDesc(value=true)
 ```
 
 Flag used to indicate descending sort order
@@ -415,7 +415,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/table/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.text
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,8 +32,8 @@ grafonnet.panel.text
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj code`](#obj-optionscode)
     * [`fn withLanguage(value="plaintext")`](#fn-optionscodewithlanguage)
-    * [`fn withShowLineNumbers(value=false)`](#fn-optionscodewithshowlinenumbers)
-    * [`fn withShowMiniMap(value=false)`](#fn-optionscodewithshowminimap)
+    * [`fn withShowLineNumbers(value=true)`](#fn-optionscodewithshowlinenumbers)
+    * [`fn withShowMiniMap(value=true)`](#fn-optionscodewithshowminimap)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.text
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -219,7 +219,7 @@ Accepted values for `value` are "plaintext", "yaml", "xml", "typescript", "sql",
 ##### fn options.code.withShowLineNumbers
 
 ```ts
-withShowLineNumbers(value=false)
+withShowLineNumbers(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withShowLineNumbers(value=false)
 ##### fn options.code.withShowMiniMap
 
 ```ts
-withShowMiniMap(value=false)
+withShowMiniMap(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/text/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.timeSeries
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.timeSeries
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -87,15 +87,15 @@ grafonnet.panel.timeSeries
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -107,7 +107,7 @@ grafonnet.panel.timeSeries
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -182,7 +182,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -200,7 +200,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -493,7 +493,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -501,7 +501,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -509,7 +509,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -620,7 +620,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -709,7 +709,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -744,7 +744,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -762,7 +762,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -778,7 +778,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -874,7 +874,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/timeSeries/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.xyChart
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,20 +41,20 @@ grafonnet.panel.xyChart
     * [`fn withFrame(value)`](#fn-optionsdimswithframe)
     * [`fn withX(value)`](#fn-optionsdimswithx)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj series`](#obj-optionsseries)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsserieswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsserieswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsserieswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsserieswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsserieswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsserieswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsserieswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsserieswithaxissoftmax)
@@ -81,9 +81,9 @@ grafonnet.panel.xyChart
     * [`fn withX(value)`](#fn-optionsserieswithx)
     * [`fn withY(value)`](#fn-optionsserieswithy)
     * [`obj hideFrom`](#obj-optionsserieshidefrom)
-      * [`fn withLegend(value)`](#fn-optionsserieshidefromwithlegend)
-      * [`fn withTooltip(value)`](#fn-optionsserieshidefromwithtooltip)
-      * [`fn withViz(value)`](#fn-optionsserieshidefromwithviz)
+      * [`fn withLegend(value=true)`](#fn-optionsserieshidefromwithlegend)
+      * [`fn withTooltip(value=true)`](#fn-optionsserieshidefromwithtooltip)
+      * [`fn withViz(value=true)`](#fn-optionsserieshidefromwithviz)
     * [`obj labelValue`](#obj-optionsserieslabelvalue)
       * [`fn withField(value)`](#fn-optionsserieslabelvaluewithfield)
       * [`fn withFixed(value)`](#fn-optionsserieslabelvaluewithfixed)
@@ -121,7 +121,7 @@ grafonnet.panel.xyChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -198,7 +198,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -364,7 +364,7 @@ withX(value)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -399,7 +399,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -417,7 +417,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -433,7 +433,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -452,7 +452,7 @@ withWidth(value)
 ##### fn options.series.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -470,7 +470,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.series.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -687,7 +687,7 @@ withY(value)
 ###### fn options.series.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -695,7 +695,7 @@ withLegend(value)
 ###### fn options.series.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -703,7 +703,7 @@ withTooltip(value)
 ###### fn options.series.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -983,7 +983,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/link.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/transformation.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/panel/xyChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/publicdashboard.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/publicdashboard.md
@@ -5,10 +5,10 @@ grafonnet.publicdashboard
 ## Index
 
 * [`fn withAccessToken(value)`](#fn-withaccesstoken)
-* [`fn withAnnotationsEnabled(value)`](#fn-withannotationsenabled)
+* [`fn withAnnotationsEnabled(value=true)`](#fn-withannotationsenabled)
 * [`fn withDashboardUid(value)`](#fn-withdashboarduid)
-* [`fn withIsEnabled(value)`](#fn-withisenabled)
-* [`fn withTimeSelectionEnabled(value)`](#fn-withtimeselectionenabled)
+* [`fn withIsEnabled(value=true)`](#fn-withisenabled)
+* [`fn withTimeSelectionEnabled(value=true)`](#fn-withtimeselectionenabled)
 * [`fn withUid(value)`](#fn-withuid)
 
 ## Fields
@@ -24,7 +24,7 @@ Unique public access token
 ### fn withAnnotationsEnabled
 
 ```ts
-withAnnotationsEnabled(value)
+withAnnotationsEnabled(value=true)
 ```
 
 Flag that indicates if annotations are enabled
@@ -40,7 +40,7 @@ Dashboard unique identifier referenced by this public dashboard
 ### fn withIsEnabled
 
 ```ts
-withIsEnabled(value)
+withIsEnabled(value=true)
 ```
 
 Flag that indicates if the public dashboard is enabled
@@ -48,7 +48,7 @@ Flag that indicates if the public dashboard is enabled
 ### fn withTimeSelectionEnabled
 
 ```ts
-withTimeSelectionEnabled(value)
+withTimeSelectionEnabled(value=true)
 ```
 
 Flag that indicates if the time range picker is enabled

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/azureMonitor.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/azureMonitor.md
@@ -13,7 +13,7 @@ grafonnet.query.azureMonitor
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGrafanaTemplateVariableFn(value)`](#fn-withgrafanatemplatevariablefn)
 * [`fn withGrafanaTemplateVariableFnMixin(value)`](#fn-withgrafanatemplatevariablefnmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withNamespace(value)`](#fn-withnamespace)
 * [`fn withQueryType(value)`](#fn-withquerytype)
 * [`fn withRefId(value)`](#fn-withrefid)
@@ -217,7 +217,7 @@ withGrafanaTemplateVariableFnMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/cloudWatch.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/cloudWatch.md
@@ -11,12 +11,12 @@ grafonnet.query.cloudWatch
   * [`fn withDatasource(value)`](#fn-cloudwatchannotationquerywithdatasource)
   * [`fn withDimensions(value)`](#fn-cloudwatchannotationquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchannotationquerywithdimensionsmixin)
-  * [`fn withHide(value)`](#fn-cloudwatchannotationquerywithhide)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchannotationquerywithmatchexact)
+  * [`fn withHide(value=true)`](#fn-cloudwatchannotationquerywithhide)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchannotationquerywithmatchexact)
   * [`fn withMetricName(value)`](#fn-cloudwatchannotationquerywithmetricname)
   * [`fn withNamespace(value)`](#fn-cloudwatchannotationquerywithnamespace)
   * [`fn withPeriod(value)`](#fn-cloudwatchannotationquerywithperiod)
-  * [`fn withPrefixMatching(value)`](#fn-cloudwatchannotationquerywithprefixmatching)
+  * [`fn withPrefixMatching(value=true)`](#fn-cloudwatchannotationquerywithprefixmatching)
   * [`fn withQueryMode(value)`](#fn-cloudwatchannotationquerywithquerymode)
   * [`fn withQueryType(value)`](#fn-cloudwatchannotationquerywithquerytype)
   * [`fn withRefId(value)`](#fn-cloudwatchannotationquerywithrefid)
@@ -27,7 +27,7 @@ grafonnet.query.cloudWatch
 * [`obj CloudWatchLogsQuery`](#obj-cloudwatchlogsquery)
   * [`fn withDatasource(value)`](#fn-cloudwatchlogsquerywithdatasource)
   * [`fn withExpression(value)`](#fn-cloudwatchlogsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchlogsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchlogsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchlogsquerywithid)
   * [`fn withLogGroupNames(value)`](#fn-cloudwatchlogsquerywithloggroupnames)
   * [`fn withLogGroupNamesMixin(value)`](#fn-cloudwatchlogsquerywithloggroupnamesmixin)
@@ -51,10 +51,10 @@ grafonnet.query.cloudWatch
   * [`fn withDimensions(value)`](#fn-cloudwatchmetricsquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchmetricsquerywithdimensionsmixin)
   * [`fn withExpression(value)`](#fn-cloudwatchmetricsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchmetricsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchmetricsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchmetricsquerywithid)
   * [`fn withLabel(value)`](#fn-cloudwatchmetricsquerywithlabel)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchmetricsquerywithmatchexact)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchmetricsquerywithmatchexact)
   * [`fn withMetricEditorMode(value)`](#fn-cloudwatchmetricsquerywithmetriceditormode)
   * [`fn withMetricName(value)`](#fn-cloudwatchmetricsquerywithmetricname)
   * [`fn withMetricQueryType(value)`](#fn-cloudwatchmetricsquerywithmetricquerytype)
@@ -185,7 +185,7 @@ withDimensionsMixin(value)
 #### fn CloudWatchAnnotationQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -195,7 +195,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 #### fn CloudWatchAnnotationQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withPeriod(value)
 #### fn CloudWatchAnnotationQuery.withPrefixMatching
 
 ```ts
-withPrefixMatching(value)
+withPrefixMatching(value=true)
 ```
 
 
@@ -318,7 +318,7 @@ withExpression(value)
 #### fn CloudWatchLogsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -510,7 +510,7 @@ Math expression query
 #### fn CloudWatchMetricsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -536,7 +536,7 @@ withLabel(value)
 #### fn CloudWatchMetricsQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/elasticsearch.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/elasticsearch.md
@@ -8,7 +8,7 @@ grafonnet.query.elasticsearch
 * [`fn withBucketAggs(value)`](#fn-withbucketaggs)
 * [`fn withBucketAggsMixin(value)`](#fn-withbucketaggsmixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withMetrics(value)`](#fn-withmetrics)
 * [`fn withMetricsMixin(value)`](#fn-withmetricsmixin)
 * [`fn withQuery(value)`](#fn-withquery)
@@ -76,13 +76,13 @@ grafonnet.query.elasticsearch
       * [`fn withSize(value)`](#fn-bucketaggstermssettingswithsize)
 * [`obj metrics`](#obj-metrics)
   * [`obj Count`](#obj-metricscount)
-    * [`fn withHide(value)`](#fn-metricscountwithhide)
+    * [`fn withHide(value=true)`](#fn-metricscountwithhide)
     * [`fn withId(value)`](#fn-metricscountwithid)
     * [`fn withType(value)`](#fn-metricscountwithtype)
   * [`obj MetricAggregationWithSettings`](#obj-metricsmetricaggregationwithsettings)
     * [`obj Average`](#obj-metricsmetricaggregationwithsettingsaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettingsmixin)
@@ -94,7 +94,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsaveragesettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsaveragesettingsscriptwithinline)
     * [`obj BucketScript`](#obj-metricsmetricaggregationwithsettingsbucketscript)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariablesmixin)
@@ -111,7 +111,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricsmetricaggregationwithsettingscumulativesum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithsettings)
@@ -121,7 +121,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricsmetricaggregationwithsettingsderivative)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithsettings)
@@ -131,7 +131,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsderivativesettingswithunit)
     * [`obj ExtendedStats`](#obj-metricsmetricaggregationwithsettingsextendedstats)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithid)
       * [`fn withMeta(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmeta)
       * [`fn withMetaMixin(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmetamixin)
@@ -146,7 +146,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsextendedstatssettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatssettingsscriptwithinline)
     * [`obj Logs`](#obj-metricsmetricaggregationwithsettingslogs)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingslogswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettingsmixin)
@@ -155,7 +155,7 @@ grafonnet.query.elasticsearch
         * [`fn withLimit(value)`](#fn-metricsmetricaggregationwithsettingslogssettingswithlimit)
     * [`obj Max`](#obj-metricsmetricaggregationwithsettingsmax)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettingsmixin)
@@ -168,7 +168,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmaxsettingsscriptwithinline)
     * [`obj Min`](#obj-metricsmetricaggregationwithsettingsmin)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsminwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsminwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettingsmixin)
@@ -181,7 +181,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsminsettingsscriptwithinline)
     * [`obj MovingAverage`](#obj-metricsmetricaggregationwithsettingsmovingaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithsettings)
@@ -189,7 +189,7 @@ grafonnet.query.elasticsearch
       * [`fn withType(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithtype)
     * [`obj MovingFunction`](#obj-metricsmetricaggregationwithsettingsmovingfunction)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithsettings)
@@ -204,7 +204,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionsettingsscriptwithinline)
     * [`obj Percentiles`](#obj-metricsmetricaggregationwithsettingspercentiles)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettingsmixin)
@@ -219,7 +219,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingspercentilessettingsscriptwithinline)
     * [`obj Rate`](#obj-metricsmetricaggregationwithsettingsrate)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsratewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsratewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettingsmixin)
@@ -228,7 +228,7 @@ grafonnet.query.elasticsearch
         * [`fn withMode(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithmode)
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithunit)
     * [`obj RawData`](#obj-metricsmetricaggregationwithsettingsrawdata)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettingsmixin)
@@ -236,7 +236,7 @@ grafonnet.query.elasticsearch
       * [`obj settings`](#obj-metricsmetricaggregationwithsettingsrawdatasettings)
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdatasettingswithsize)
     * [`obj RawDocument`](#obj-metricsmetricaggregationwithsettingsrawdocument)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettingsmixin)
@@ -245,7 +245,7 @@ grafonnet.query.elasticsearch
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentsettingswithsize)
     * [`obj SerialDiff`](#obj-metricsmetricaggregationwithsettingsserialdiff)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithsettings)
@@ -255,7 +255,7 @@ grafonnet.query.elasticsearch
         * [`fn withLag(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffsettingswithlag)
     * [`obj Sum`](#obj-metricsmetricaggregationwithsettingssum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingssumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingssumwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettingsmixin)
@@ -267,7 +267,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingssumsettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingssumsettingsscriptwithinline)
     * [`obj TopMetrics`](#obj-metricsmetricaggregationwithsettingstopmetrics)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettingsmixin)
@@ -279,7 +279,7 @@ grafonnet.query.elasticsearch
         * [`fn withOrderBy(value)`](#fn-metricsmetricaggregationwithsettingstopmetricssettingswithorderby)
     * [`obj UniqueCount`](#obj-metricsmetricaggregationwithsettingsuniquecount)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettingsmixin)
@@ -289,7 +289,7 @@ grafonnet.query.elasticsearch
         * [`fn withPrecisionThreshold(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountsettingswithprecisionthreshold)
   * [`obj PipelineMetricAggregation`](#obj-metricspipelinemetricaggregation)
     * [`obj BucketScript`](#obj-metricspipelinemetricaggregationbucketscript)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariablesmixin)
@@ -306,7 +306,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricspipelinemetricaggregationbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricspipelinemetricaggregationcumulativesum)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithsettings)
@@ -316,7 +316,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricspipelinemetricaggregationcumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricspipelinemetricaggregationderivative)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationderivativewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationderivativewithsettings)
@@ -326,7 +326,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricspipelinemetricaggregationderivativesettingswithunit)
     * [`obj MovingAverage`](#obj-metricspipelinemetricaggregationmovingaverage)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithsettings)
@@ -373,7 +373,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -849,7 +849,7 @@ withSize(value)
 ##### fn metrics.Count.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -887,7 +887,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Average.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -968,7 +968,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1084,7 +1084,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1154,7 +1154,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1224,7 +1224,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.ExtendedStats.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1329,7 +1329,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.Logs.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1391,7 +1391,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Max.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1480,7 +1480,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Min.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1569,7 +1569,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1628,7 +1628,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingFunction.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1733,7 +1733,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Percentiles.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1838,7 +1838,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Rate.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1900,7 +1900,7 @@ withUnit(value)
 ###### fn metrics.MetricAggregationWithSettings.RawData.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1954,7 +1954,7 @@ withSize(value)
 ###### fn metrics.MetricAggregationWithSettings.RawDocument.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2016,7 +2016,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.SerialDiff.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2086,7 +2086,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Sum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2167,7 +2167,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.TopMetrics.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2253,7 +2253,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.UniqueCount.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2318,7 +2318,7 @@ withPrecisionThreshold(value)
 ###### fn metrics.PipelineMetricAggregation.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2434,7 +2434,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2504,7 +2504,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2574,7 +2574,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/loki.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/loki.md
@@ -8,12 +8,12 @@ grafonnet.query.loki
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
 * [`fn withExpr(value)`](#fn-withexpr)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withMaxLines(value)`](#fn-withmaxlines)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 * [`fn withResolution(value)`](#fn-withresolution)
 
@@ -56,7 +56,7 @@ The LogQL query.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -66,7 +66,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 @deprecated, now use queryType.
@@ -99,7 +99,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 @deprecated, now use queryType.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/parca.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/parca.md
@@ -5,7 +5,7 @@ grafonnet.query.parca
 ## Index
 
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -27,7 +27,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/phlare.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/phlare.md
@@ -7,7 +7,7 @@ grafonnet.query.phlare
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGroupBy(value)`](#fn-withgroupby)
 * [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -45,7 +45,7 @@ Allows to group the results.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/prometheus.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/prometheus.md
@@ -7,15 +7,15 @@ grafonnet.query.prometheus
 * [`fn new(datasource, expr)`](#fn-new)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
-* [`fn withExemplar(value)`](#fn-withexemplar)
+* [`fn withExemplar(value=true)`](#fn-withexemplar)
 * [`fn withExpr(value)`](#fn-withexpr)
 * [`fn withFormat(value)`](#fn-withformat)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withIntervalFactor(value)`](#fn-withintervalfactor)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 
 ## Fields
@@ -49,7 +49,7 @@ Accepted values for `value` are "code", "builder"
 ### fn withExemplar
 
 ```ts
-withExemplar(value)
+withExemplar(value=true)
 ```
 
 Execute an additional query to identify interesting raw samples relevant for the given expr
@@ -75,7 +75,7 @@ Accepted values for `value` are "time_series", "table", "heatmap"
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -85,7 +85,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 Returns only the latest value that Prometheus has scraped for the requested time series
@@ -118,7 +118,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/tempo.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/tempo.md
@@ -8,7 +8,7 @@ grafonnet.query.tempo
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withFilters(value)`](#fn-withfilters)
 * [`fn withFiltersMixin(value)`](#fn-withfiltersmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLimit(value)`](#fn-withlimit)
 * [`fn withMaxDuration(value)`](#fn-withmaxduration)
 * [`fn withMinDuration(value)`](#fn-withminduration)
@@ -66,7 +66,7 @@ withFiltersMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/query/testData.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/query/testData.md
@@ -12,9 +12,9 @@ grafonnet.query.testData
 * [`fn withCsvWaveMixin(value)`](#fn-withcsvwavemixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withErrorType(value)`](#fn-witherrortype)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabels(value)`](#fn-withlabels)
-* [`fn withLevelColumn(value)`](#fn-withlevelcolumn)
+* [`fn withLevelColumn(value=true)`](#fn-withlevelcolumn)
 * [`fn withLines(value)`](#fn-withlines)
 * [`fn withNodes(value)`](#fn-withnodes)
 * [`fn withNodesMixin(value)`](#fn-withnodesmixin)
@@ -54,8 +54,8 @@ grafonnet.query.testData
   * [`fn withConfigMixin(value)`](#fn-simwithconfigmixin)
   * [`fn withKey(value)`](#fn-simwithkey)
   * [`fn withKeyMixin(value)`](#fn-simwithkeymixin)
-  * [`fn withLast(value)`](#fn-simwithlast)
-  * [`fn withStream(value)`](#fn-simwithstream)
+  * [`fn withLast(value=true)`](#fn-simwithlast)
+  * [`fn withStream(value=true)`](#fn-simwithstream)
   * [`obj key`](#obj-simkey)
     * [`fn withTick(value)`](#fn-simkeywithtick)
     * [`fn withType(value)`](#fn-simkeywithtype)
@@ -149,7 +149,7 @@ Accepted values for `value` are "server_panic", "frontend_exception", "frontend_
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -167,7 +167,7 @@ withLabels(value)
 ### fn withLevelColumn
 
 ```ts
-withLevelColumn(value)
+withLevelColumn(value=true)
 ```
 
 
@@ -474,7 +474,7 @@ withKeyMixin(value)
 #### fn sim.withLast
 
 ```ts
-withLast(value)
+withLast(value=true)
 ```
 
 
@@ -482,7 +482,7 @@ withLast(value)
 #### fn sim.withStream
 
 ```ts
-withStream(value)
+withStream(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/serviceaccount.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/serviceaccount.md
@@ -9,7 +9,7 @@ grafonnet.serviceaccount
 * [`fn withAvatarUrl(value)`](#fn-withavatarurl)
 * [`fn withCreated(value)`](#fn-withcreated)
 * [`fn withId(value)`](#fn-withid)
-* [`fn withIsDisabled(value)`](#fn-withisdisabled)
+* [`fn withIsDisabled(value=true)`](#fn-withisdisabled)
 * [`fn withLogin(value)`](#fn-withlogin)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withOrgId(value)`](#fn-withorgid)
@@ -65,7 +65,7 @@ ID is the unique identifier of the service account in the database.
 ### fn withIsDisabled
 
 ```ts
-withIsDisabled(value)
+withIsDisabled(value=true)
 ```
 
 IsDisabled indicates if the service account is disabled.

--- a/gen/grafonnet-v9.4.0/docs/grafonnet/util.md
+++ b/gen/grafonnet-v9.4.0/docs/grafonnet/util.md
@@ -7,7 +7,8 @@ Helper functions that work well with Grafonnet.
 * [`obj dashboard`](#obj-dashboard)
   * [`fn getOptionsForCustomQuery(query)`](#fn-dashboardgetoptionsforcustomquery)
 * [`obj grid`](#obj-grid)
-  * [`fn makeGrid(panels, panelWidth, panelHeight)`](#fn-gridmakegrid)
+  * [`fn makeGrid(panels, panelWidth, panelHeight, startY)`](#fn-gridmakegrid)
+  * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
 * [`obj string`](#obj-string)
@@ -40,7 +41,7 @@ compatible solution.
 #### fn grid.makeGrid
 
 ```ts
-makeGrid(panels, panelWidth, panelHeight)
+makeGrid(panels, panelWidth, panelHeight, startY)
 ```
 
 `makeGrid` returns an array of `panels` organized in a grid with equal `panelWidth`
@@ -50,6 +51,18 @@ then all panels below it will be folded into the row.
 This function will use the full grid of 24 columns, setting `panelWidth` to a value
 that can divide 24 into equal parts will fill up the page nicely. (1, 2, 3, 4, 6, 8, 12)
 Other value for `panelWidth` will leave a gap on the far right.
+
+Optional `startY` can be provided to place generated grid above or below existing panels.
+
+
+#### fn grid.wrapPanels
+
+```ts
+wrapPanels(panels, panelWidth, panelHeight, startY)
+```
+
+`wrapPanels` returns an array of `panels` organized in a grid, wrapping up to next 'row' if total width exceeds full grid of 24 columns.
+'panelHeight' and 'panelWidth' are used unless panels already have height and width defined.
 
 
 ### obj panel

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/annotation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/annotation.md
@@ -8,7 +8,7 @@
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withEnable(value=true)`](#fn-withenable)
-* [`fn withHide(value=false)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withIconColor(value)`](#fn-withiconcolor)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withRawQuery(value)`](#fn-withrawquery)
@@ -21,7 +21,7 @@
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj target`](#obj-target)
   * [`fn withLimit(value)`](#fn-targetwithlimit)
-  * [`fn withMatchAny(value)`](#fn-targetwithmatchany)
+  * [`fn withMatchAny(value=true)`](#fn-targetwithmatchany)
   * [`fn withTags(value)`](#fn-targetwithtags)
   * [`fn withTagsMixin(value)`](#fn-targetwithtagsmixin)
   * [`fn withType(value)`](#fn-targetwithtype)
@@ -63,7 +63,7 @@ Whether annotation is enabled.
 ### fn withHide
 
 ```ts
-withHide(value=false)
+withHide(value=true)
 ```
 
 Whether to hide annotation.
@@ -157,7 +157,7 @@ withLimit(value)
 #### fn target.withMatchAny
 
 ```ts
-withMatchAny(value)
+withMatchAny(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/index.md
@@ -18,7 +18,7 @@ grafonnet.dashboard
 * [`fn withFiscalYearStartMonth(value=0)`](#fn-withfiscalyearstartmonth)
 * [`fn withLinks(value)`](#fn-withlinks)
 * [`fn withLinksMixin(value)`](#fn-withlinksmixin)
-* [`fn withLiveNow(value)`](#fn-withlivenow)
+* [`fn withLiveNow(value=true)`](#fn-withlivenow)
 * [`fn withPanels(value)`](#fn-withpanels)
 * [`fn withPanelsMixin(value)`](#fn-withpanelsmixin)
 * [`fn withRefresh(value)`](#fn-withrefresh)
@@ -42,9 +42,9 @@ grafonnet.dashboard
   * [`fn withFrom(value="now-6h")`](#fn-timewithfrom)
   * [`fn withTo(value="now")`](#fn-timewithto)
 * [`obj timepicker`](#obj-timepicker)
-  * [`fn withCollapse(value=false)`](#fn-timepickerwithcollapse)
+  * [`fn withCollapse(value=true)`](#fn-timepickerwithcollapse)
   * [`fn withEnable(value=true)`](#fn-timepickerwithenable)
-  * [`fn withHidden(value=false)`](#fn-timepickerwithhidden)
+  * [`fn withHidden(value=true)`](#fn-timepickerwithhidden)
   * [`fn withRefreshIntervals(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervals)
   * [`fn withRefreshIntervalsMixin(value=["5s","10s","30s","1m","5m","15m","30m","1h","2h","1d"])`](#fn-timepickerwithrefreshintervalsmixin)
   * [`fn withTimeOptions(value=["5m","15m","1h","6h","12h","24h","2d","7d","30d"])`](#fn-timepickerwithtimeoptions)
@@ -159,7 +159,7 @@ g.dashboard.new('Title dashboard')
 ### fn withLiveNow
 
 ```ts
-withLiveNow(value)
+withLiveNow(value=true)
 ```
 
 When set to true, the dashboard will redraw panels at an interval matching the pixel width.
@@ -346,7 +346,7 @@ withTo(value="now")
 #### fn timepicker.withCollapse
 
 ```ts
-withCollapse(value=false)
+withCollapse(value=true)
 ```
 
 Whether timepicker is collapsed or not.
@@ -362,7 +362,7 @@ Whether timepicker is enabled or not.
 #### fn timepicker.withHidden
 
 ```ts
-withHidden(value=false)
+withHidden(value=true)
 ```
 
 Whether timepicker is visible or not.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/link.md
@@ -22,19 +22,19 @@ g.dashboard.new('Title dashboard')
 * [`obj dashboards`](#obj-dashboards)
   * [`fn new(title, tags)`](#fn-dashboardsnew)
   * [`obj options`](#obj-dashboardsoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-dashboardsoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-dashboardsoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-dashboardsoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-dashboardsoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-dashboardsoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-dashboardsoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-dashboardsoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-dashboardsoptionswithtargetblank)
 * [`obj link`](#obj-link)
   * [`fn new(title, url)`](#fn-linknew)
   * [`fn withIcon(value)`](#fn-linkwithicon)
   * [`fn withTooltip(value)`](#fn-linkwithtooltip)
   * [`obj options`](#obj-linkoptions)
-    * [`fn withAsDropdown(value=false)`](#fn-linkoptionswithasdropdown)
-    * [`fn withIncludeVars(value=false)`](#fn-linkoptionswithincludevars)
-    * [`fn withKeepTime(value=false)`](#fn-linkoptionswithkeeptime)
-    * [`fn withTargetBlank(value=false)`](#fn-linkoptionswithtargetblank)
+    * [`fn withAsDropdown(value=true)`](#fn-linkoptionswithasdropdown)
+    * [`fn withIncludeVars(value=true)`](#fn-linkoptionswithincludevars)
+    * [`fn withKeepTime(value=true)`](#fn-linkoptionswithkeeptime)
+    * [`fn withTargetBlank(value=true)`](#fn-linkoptionswithtargetblank)
 
 ## Fields
 
@@ -56,7 +56,7 @@ Create links to dashboards based on `tags`.
 ##### fn dashboards.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -64,7 +64,7 @@ withAsDropdown(value=false)
 ##### fn dashboards.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -72,7 +72,7 @@ withIncludeVars(value=false)
 ##### fn dashboards.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -80,7 +80,7 @@ withKeepTime(value=false)
 ##### fn dashboards.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 
@@ -119,7 +119,7 @@ withTooltip(value)
 ##### fn link.options.withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -127,7 +127,7 @@ withAsDropdown(value=false)
 ##### fn link.options.withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -135,7 +135,7 @@ withIncludeVars(value=false)
 ##### fn link.options.withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -143,7 +143,7 @@ withKeepTime(value=false)
 ##### fn link.options.withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/variable.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/dashboard/variable.md
@@ -113,7 +113,7 @@ g.dashboard.new('my dashboard')
       * [`fn withNothing()`](#fn-querygeneraloptionsshowondashboardwithnothing)
       * [`fn withValueOnly()`](#fn-querygeneraloptionsshowondashboardwithvalueonly)
   * [`obj queryTypes`](#obj-queryquerytypes)
-    * [`fn withLabelValues(label, metric)`](#fn-queryquerytypeswithlabelvalues)
+    * [`fn withLabelValues(label, metric="")`](#fn-queryquerytypeswithlabelvalues)
   * [`obj refresh`](#obj-queryrefresh)
     * [`fn onLoad()`](#fn-queryrefreshonload)
     * [`fn onTime()`](#fn-queryrefreshontime)
@@ -668,7 +668,7 @@ withValueOnly()
 ##### fn query.queryTypes.withLabelValues
 
 ```ts
-withLabelValues(label, metric)
+withLabelValues(label, metric="")
 ```
 
 Construct a Prometheus template variable using `label_values()`.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,7 +27,7 @@ grafonnet.panel.alertGroups
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withAlertmanager(value)`](#fn-optionswithalertmanager)
-  * [`fn withExpandAll(value)`](#fn-optionswithexpandall)
+  * [`fn withExpandAll(value=true)`](#fn-optionswithexpandall)
   * [`fn withLabels(value)`](#fn-optionswithlabels)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -36,7 +36,7 @@ grafonnet.panel.alertGroups
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -113,7 +113,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -175,7 +175,7 @@ Name of the alertmanager used as a source for alerts
 #### fn options.withExpandAll
 
 ```ts
-withExpandAll(value)
+withExpandAll(value=true)
 ```
 
 Expand all alert groups by default
@@ -248,7 +248,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/alertGroups/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.annotationsList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,8 +30,8 @@ grafonnet.panel.annotationsList
   * [`fn withNavigateAfter(value="10m")`](#fn-optionswithnavigateafter)
   * [`fn withNavigateBefore(value="10m")`](#fn-optionswithnavigatebefore)
   * [`fn withNavigateToPanel(value=true)`](#fn-optionswithnavigatetopanel)
-  * [`fn withOnlyFromThisDashboard(value=false)`](#fn-optionswithonlyfromthisdashboard)
-  * [`fn withOnlyInTimeRange(value=false)`](#fn-optionswithonlyintimerange)
+  * [`fn withOnlyFromThisDashboard(value=true)`](#fn-optionswithonlyfromthisdashboard)
+  * [`fn withOnlyInTimeRange(value=true)`](#fn-optionswithonlyintimerange)
   * [`fn withShowTags(value=true)`](#fn-optionswithshowtags)
   * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withShowUser(value=true)`](#fn-optionswithshowuser)
@@ -44,7 +44,7 @@ grafonnet.panel.annotationsList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -121,7 +121,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -207,7 +207,7 @@ withNavigateToPanel(value=true)
 #### fn options.withOnlyFromThisDashboard
 
 ```ts
-withOnlyFromThisDashboard(value=false)
+withOnlyFromThisDashboard(value=true)
 ```
 
 
@@ -215,7 +215,7 @@ withOnlyFromThisDashboard(value=false)
 #### fn options.withOnlyInTimeRange
 
 ```ts
-withOnlyInTimeRange(value=false)
+withOnlyInTimeRange(value=true)
 ```
 
 
@@ -320,7 +320,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/annotationsList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.barChart
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -37,9 +37,9 @@ grafonnet.panel.barChart
       * [`fn withThresholdsStyle(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstyle)
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
@@ -48,7 +48,7 @@ grafonnet.panel.barChart
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -59,7 +59,7 @@ grafonnet.panel.barChart
   * [`fn withBarRadius(value=0)`](#fn-optionswithbarradius)
   * [`fn withBarWidth(value=0.97)`](#fn-optionswithbarwidth)
   * [`fn withColorByField(value)`](#fn-optionswithcolorbyfield)
-  * [`fn withFullHighlight(value=false)`](#fn-optionswithfullhighlight)
+  * [`fn withFullHighlight(value=true)`](#fn-optionswithfullhighlight)
   * [`fn withGroupWidth(value=0.7)`](#fn-optionswithgroupwidth)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
@@ -75,15 +75,15 @@ grafonnet.panel.barChart
   * [`fn withXTickLabelRotation(value=0)`](#fn-optionswithxticklabelrotation)
   * [`fn withXTickLabelSpacing(value=0)`](#fn-optionswithxticklabelspacing)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
@@ -98,7 +98,7 @@ grafonnet.panel.barChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -191,7 +191,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -318,7 +318,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -326,7 +326,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -334,7 +334,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -395,7 +395,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -473,7 +473,7 @@ Use the color value for a sibling field to color each bar value.
 #### fn options.withFullHighlight
 
 ```ts
-withFullHighlight(value=false)
+withFullHighlight(value=true)
 ```
 
 Enables mode which highlights the entire bar area and shows tooltip when cursor
@@ -604,7 +604,7 @@ negative values indicate backwards skipping behavior
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -639,7 +639,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -657,7 +657,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -673,7 +673,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -788,7 +788,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.barGauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.barGauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -52,7 +52,7 @@ grafonnet.panel.barGauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -129,7 +129,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -305,7 +305,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -389,7 +389,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/barGauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.candlestick
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.candlestick
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/candlestick/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.canvas
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,7 +32,7 @@ grafonnet.panel.canvas
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -109,7 +109,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -217,7 +217,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/canvas/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.dashboardList
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,8 +31,8 @@ grafonnet.panel.dashboardList
   * [`fn withMaxItems(value=10)`](#fn-optionswithmaxitems)
   * [`fn withQuery(value="")`](#fn-optionswithquery)
   * [`fn withShowHeadings(value=true)`](#fn-optionswithshowheadings)
-  * [`fn withShowRecentlyViewed(value=false)`](#fn-optionswithshowrecentlyviewed)
-  * [`fn withShowSearch(value=false)`](#fn-optionswithshowsearch)
+  * [`fn withShowRecentlyViewed(value=true)`](#fn-optionswithshowrecentlyviewed)
+  * [`fn withShowSearch(value=true)`](#fn-optionswithshowsearch)
   * [`fn withShowStarred(value=true)`](#fn-optionswithshowstarred)
   * [`fn withTags(value)`](#fn-optionswithtags)
   * [`fn withTagsMixin(value)`](#fn-optionswithtagsmixin)
@@ -43,7 +43,7 @@ grafonnet.panel.dashboardList
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -120,7 +120,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -216,7 +216,7 @@ withShowHeadings(value=true)
 #### fn options.withShowRecentlyViewed
 
 ```ts
-withShowRecentlyViewed(value=false)
+withShowRecentlyViewed(value=true)
 ```
 
 
@@ -224,7 +224,7 @@ withShowRecentlyViewed(value=false)
 #### fn options.withShowSearch
 
 ```ts
-withShowSearch(value=false)
+withShowSearch(value=true)
 ```
 
 
@@ -313,7 +313,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/dashboardList/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.debug
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -30,9 +30,9 @@ grafonnet.panel.debug
   * [`fn withCountersMixin(value)`](#fn-optionswithcountersmixin)
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj counters`](#obj-optionscounters)
-    * [`fn withDataChanged(value)`](#fn-optionscounterswithdatachanged)
-    * [`fn withRender(value)`](#fn-optionscounterswithrender)
-    * [`fn withSchemaChanged(value)`](#fn-optionscounterswithschemachanged)
+    * [`fn withDataChanged(value=true)`](#fn-optionscounterswithdatachanged)
+    * [`fn withRender(value=true)`](#fn-optionscounterswithrender)
+    * [`fn withSchemaChanged(value=true)`](#fn-optionscounterswithschemachanged)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -40,7 +40,7 @@ grafonnet.panel.debug
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -117,7 +117,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -200,7 +200,7 @@ Accepted values for `value` are "render", "events", "cursor", "State", "ThrowErr
 ##### fn options.counters.withDataChanged
 
 ```ts
-withDataChanged(value)
+withDataChanged(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ withDataChanged(value)
 ##### fn options.counters.withRender
 
 ```ts
-withRender(value)
+withRender(value=true)
 ```
 
 
@@ -216,7 +216,7 @@ withRender(value)
 ##### fn options.counters.withSchemaChanged
 
 ```ts
-withSchemaChanged(value)
+withSchemaChanged(value=true)
 ```
 
 
@@ -281,7 +281,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/debug/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.gauge
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -29,7 +29,7 @@ grafonnet.panel.gauge
   * [`fn withOrientation(value)`](#fn-optionswithorientation)
   * [`fn withReduceOptions(value)`](#fn-optionswithreduceoptions)
   * [`fn withReduceOptionsMixin(value)`](#fn-optionswithreduceoptionsmixin)
-  * [`fn withShowThresholdLabels(value=false)`](#fn-optionswithshowthresholdlabels)
+  * [`fn withShowThresholdLabels(value=true)`](#fn-optionswithshowthresholdlabels)
   * [`fn withShowThresholdMarkers(value=true)`](#fn-optionswithshowthresholdmarkers)
   * [`fn withText(value)`](#fn-optionswithtext)
   * [`fn withTextMixin(value)`](#fn-optionswithtextmixin)
@@ -38,7 +38,7 @@ grafonnet.panel.gauge
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -49,7 +49,7 @@ grafonnet.panel.gauge
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -126,7 +126,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -206,7 +206,7 @@ TODO docs
 #### fn options.withShowThresholdLabels
 
 ```ts
-withShowThresholdLabels(value=false)
+withShowThresholdLabels(value=true)
 ```
 
 
@@ -273,7 +273,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -357,7 +357,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/gauge/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.geomap
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -43,7 +43,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionsbasemapwithlocationmixin)
     * [`fn withName(value)`](#fn-optionsbasemapwithname)
     * [`fn withOpacity(value)`](#fn-optionsbasemapwithopacity)
-    * [`fn withTooltip(value)`](#fn-optionsbasemapwithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionsbasemapwithtooltip)
     * [`fn withType(value)`](#fn-optionsbasemapwithtype)
     * [`obj location`](#obj-optionsbasemaplocation)
       * [`fn withGazetteer(value)`](#fn-optionsbasemaplocationwithgazetteer)
@@ -54,12 +54,12 @@ grafonnet.panel.geomap
       * [`fn withMode(value)`](#fn-optionsbasemaplocationwithmode)
       * [`fn withWkt(value)`](#fn-optionsbasemaplocationwithwkt)
   * [`obj controls`](#obj-optionscontrols)
-    * [`fn withMouseWheelZoom(value)`](#fn-optionscontrolswithmousewheelzoom)
-    * [`fn withShowAttribution(value)`](#fn-optionscontrolswithshowattribution)
-    * [`fn withShowDebug(value)`](#fn-optionscontrolswithshowdebug)
-    * [`fn withShowMeasure(value)`](#fn-optionscontrolswithshowmeasure)
-    * [`fn withShowScale(value)`](#fn-optionscontrolswithshowscale)
-    * [`fn withShowZoom(value)`](#fn-optionscontrolswithshowzoom)
+    * [`fn withMouseWheelZoom(value=true)`](#fn-optionscontrolswithmousewheelzoom)
+    * [`fn withShowAttribution(value=true)`](#fn-optionscontrolswithshowattribution)
+    * [`fn withShowDebug(value=true)`](#fn-optionscontrolswithshowdebug)
+    * [`fn withShowMeasure(value=true)`](#fn-optionscontrolswithshowmeasure)
+    * [`fn withShowScale(value=true)`](#fn-optionscontrolswithshowscale)
+    * [`fn withShowZoom(value=true)`](#fn-optionscontrolswithshowzoom)
   * [`obj layers`](#obj-optionslayers)
     * [`fn withConfig(value)`](#fn-optionslayerswithconfig)
     * [`fn withFilterData(value)`](#fn-optionslayerswithfilterdata)
@@ -67,7 +67,7 @@ grafonnet.panel.geomap
     * [`fn withLocationMixin(value)`](#fn-optionslayerswithlocationmixin)
     * [`fn withName(value)`](#fn-optionslayerswithname)
     * [`fn withOpacity(value)`](#fn-optionslayerswithopacity)
-    * [`fn withTooltip(value)`](#fn-optionslayerswithtooltip)
+    * [`fn withTooltip(value=true)`](#fn-optionslayerswithtooltip)
     * [`fn withType(value)`](#fn-optionslayerswithtype)
     * [`obj location`](#obj-optionslayerslocation)
       * [`fn withGazetteer(value)`](#fn-optionslayerslocationwithgazetteer)
@@ -82,14 +82,14 @@ grafonnet.panel.geomap
   * [`obj view`](#obj-optionsview)
     * [`fn withAllLayers(value=true)`](#fn-optionsviewwithalllayers)
     * [`fn withId(value="zero")`](#fn-optionsviewwithid)
-    * [`fn withLastOnly(value)`](#fn-optionsviewwithlastonly)
+    * [`fn withLastOnly(value=true)`](#fn-optionsviewwithlastonly)
     * [`fn withLat(value=0)`](#fn-optionsviewwithlat)
     * [`fn withLayer(value)`](#fn-optionsviewwithlayer)
     * [`fn withLon(value=0)`](#fn-optionsviewwithlon)
     * [`fn withMaxZoom(value)`](#fn-optionsviewwithmaxzoom)
     * [`fn withMinZoom(value)`](#fn-optionsviewwithminzoom)
     * [`fn withPadding(value)`](#fn-optionsviewwithpadding)
-    * [`fn withShared(value)`](#fn-optionsviewwithshared)
+    * [`fn withShared(value=true)`](#fn-optionsviewwithshared)
     * [`fn withZoom(value=1)`](#fn-optionsviewwithzoom)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -98,7 +98,7 @@ grafonnet.panel.geomap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -175,7 +175,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -362,7 +362,7 @@ Layer opacity (0-1)
 ##### fn options.basemap.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -442,7 +442,7 @@ withWkt(value)
 ##### fn options.controls.withMouseWheelZoom
 
 ```ts
-withMouseWheelZoom(value)
+withMouseWheelZoom(value=true)
 ```
 
 let the mouse wheel zoom
@@ -450,7 +450,7 @@ let the mouse wheel zoom
 ##### fn options.controls.withShowAttribution
 
 ```ts
-withShowAttribution(value)
+withShowAttribution(value=true)
 ```
 
 Lower right
@@ -458,7 +458,7 @@ Lower right
 ##### fn options.controls.withShowDebug
 
 ```ts
-withShowDebug(value)
+withShowDebug(value=true)
 ```
 
 Show debug
@@ -466,7 +466,7 @@ Show debug
 ##### fn options.controls.withShowMeasure
 
 ```ts
-withShowMeasure(value)
+withShowMeasure(value=true)
 ```
 
 Show measure
@@ -474,7 +474,7 @@ Show measure
 ##### fn options.controls.withShowScale
 
 ```ts
-withShowScale(value)
+withShowScale(value=true)
 ```
 
 Scale options
@@ -482,7 +482,7 @@ Scale options
 ##### fn options.controls.withShowZoom
 
 ```ts
-withShowZoom(value)
+withShowZoom(value=true)
 ```
 
 Zoom (upper left)
@@ -543,7 +543,7 @@ Layer opacity (0-1)
 ##### fn options.layers.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 Check tooltip (defaults to true)
@@ -652,7 +652,7 @@ withId(value="zero")
 ##### fn options.view.withLastOnly
 
 ```ts
-withLastOnly(value)
+withLastOnly(value=true)
 ```
 
 
@@ -708,7 +708,7 @@ withPadding(value)
 ##### fn options.view.withShared
 
 ```ts
-withShared(value)
+withShared(value=true)
 ```
 
 
@@ -781,7 +781,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/geomap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/index.md
@@ -24,16 +24,16 @@ grafonnet.panel.heatmap
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,7 +41,7 @@ grafonnet.panel.heatmap
   * [`fn withName(value)`](#fn-librarypanelwithname)
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
-  * [`fn withCalculate(value=false)`](#fn-optionswithcalculate)
+  * [`fn withCalculate(value=true)`](#fn-optionswithcalculate)
   * [`fn withCalculation(value)`](#fn-optionswithcalculation)
   * [`fn withCalculationMixin(value)`](#fn-optionswithcalculationmixin)
   * [`fn withCellGap(value=1)`](#fn-optionswithcellgap)
@@ -101,7 +101,7 @@ grafonnet.panel.heatmap
       * [`fn withMax(value)`](#fn-optionscolorheatmapcoloroptionswithmax)
       * [`fn withMin(value)`](#fn-optionscolorheatmapcoloroptionswithmin)
       * [`fn withMode(value)`](#fn-optionscolorheatmapcoloroptionswithmode)
-      * [`fn withReverse(value)`](#fn-optionscolorheatmapcoloroptionswithreverse)
+      * [`fn withReverse(value=true)`](#fn-optionscolorheatmapcoloroptionswithreverse)
       * [`fn withScale(value)`](#fn-optionscolorheatmapcoloroptionswithscale)
       * [`fn withScheme(value)`](#fn-optionscolorheatmapcoloroptionswithscheme)
       * [`fn withSteps(value)`](#fn-optionscolorheatmapcoloroptionswithsteps)
@@ -114,17 +114,17 @@ grafonnet.panel.heatmap
       * [`fn withGe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithge)
       * [`fn withLe(value)`](#fn-optionsfiltervaluesfiltervaluerangewithle)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withShow(value)`](#fn-optionslegendwithshow)
+    * [`fn withShow(value=true)`](#fn-optionslegendwithshow)
   * [`obj rowsFrame`](#obj-optionsrowsframe)
     * [`fn withLayout(value)`](#fn-optionsrowsframewithlayout)
     * [`fn withValue(value)`](#fn-optionsrowsframewithvalue)
   * [`obj tooltip`](#obj-optionstooltip)
-    * [`fn withShow(value)`](#fn-optionstooltipwithshow)
-    * [`fn withYHistogram(value)`](#fn-optionstooltipwithyhistogram)
+    * [`fn withShow(value=true)`](#fn-optionstooltipwithshow)
+    * [`fn withYHistogram(value=true)`](#fn-optionstooltipwithyhistogram)
   * [`obj yAxis`](#obj-optionsyaxis)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsyaxiswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsyaxiswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsyaxiswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsyaxiswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsyaxiswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsyaxiswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsyaxiswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsyaxiswithaxissoftmax)
@@ -133,7 +133,7 @@ grafonnet.panel.heatmap
     * [`fn withDecimals(value)`](#fn-optionsyaxiswithdecimals)
     * [`fn withMax(value)`](#fn-optionsyaxiswithmax)
     * [`fn withMin(value)`](#fn-optionsyaxiswithmin)
-    * [`fn withReverse(value)`](#fn-optionsyaxiswithreverse)
+    * [`fn withReverse(value=true)`](#fn-optionsyaxiswithreverse)
     * [`fn withScaleDistribution(value)`](#fn-optionsyaxiswithscaledistribution)
     * [`fn withScaleDistributionMixin(value)`](#fn-optionsyaxiswithscaledistributionmixin)
     * [`fn withUnit(value)`](#fn-optionsyaxiswithunit)
@@ -148,7 +148,7 @@ grafonnet.panel.heatmap
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -258,7 +258,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -266,7 +266,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -274,7 +274,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -322,7 +322,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -376,7 +376,7 @@ withUid(value)
 #### fn options.withCalculate
 
 ```ts
-withCalculate(value=false)
+withCalculate(value=true)
 ```
 
 Controls if the heatmap should be calculated from data
@@ -823,7 +823,7 @@ Accepted values for `value` are "opacity", "scheme"
 ###### fn options.color.HeatmapColorOptions.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the color scheme
@@ -909,7 +909,7 @@ Sets the filter range to values less than or equal to the given value
 ##### fn options.legend.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the legend is shown
@@ -941,7 +941,7 @@ Sets the name of the cell when not calculating from data
 ##### fn options.tooltip.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 Controls if the tooltip is shown
@@ -949,7 +949,7 @@ Controls if the tooltip is shown
 ##### fn options.tooltip.withYHistogram
 
 ```ts
-withYHistogram(value)
+withYHistogram(value=true)
 ```
 
 Controls if the tooltip shows a histogram of the y-axis values
@@ -960,7 +960,7 @@ Controls if the tooltip shows a histogram of the y-axis values
 ##### fn options.yAxis.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -978,7 +978,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.yAxis.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -1052,7 +1052,7 @@ Sets the minimum value for the yAxis
 ##### fn options.yAxis.withReverse
 
 ```ts
-withReverse(value)
+withReverse(value=true)
 ```
 
 Reverses the yAxis
@@ -1170,7 +1170,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/heatmap/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.histogram
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -35,16 +35,16 @@ grafonnet.panel.histogram
       * [`fn withScaleDistribution(value)`](#fn-fieldconfigdefaultscustomwithscaledistribution)
       * [`fn withScaleDistributionMixin(value)`](#fn-fieldconfigdefaultscustomwithscaledistributionmixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj scaleDistribution`](#obj-fieldconfigdefaultscustomscaledistribution)
         * [`fn withLinearThreshold(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlinearthreshold)
         * [`fn withLog(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithlog)
         * [`fn withType(value)`](#fn-fieldconfigdefaultscustomscaledistributionwithtype)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -54,21 +54,21 @@ grafonnet.panel.histogram
 * [`obj options`](#obj-options)
   * [`fn withBucketOffset(value=0)`](#fn-optionswithbucketoffset)
   * [`fn withBucketSize(value)`](#fn-optionswithbucketsize)
-  * [`fn withCombine(value)`](#fn-optionswithcombine)
+  * [`fn withCombine(value=true)`](#fn-optionswithcombine)
   * [`fn withLegend(value)`](#fn-optionswithlegend)
   * [`fn withLegendMixin(value)`](#fn-optionswithlegendmixin)
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -80,7 +80,7 @@ grafonnet.panel.histogram
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -155,7 +155,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -173,7 +173,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -284,7 +284,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -300,7 +300,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -348,7 +348,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -418,7 +418,7 @@ Size of each bucket
 #### fn options.withCombine
 
 ```ts
-withCombine(value)
+withCombine(value=true)
 ```
 
 Combines multiple series into a single histogram
@@ -461,7 +461,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -496,7 +496,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -514,7 +514,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -530,7 +530,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -626,7 +626,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/histogram/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -27,13 +27,13 @@ grafonnet.panel.logs
   * [`fn withUid(value)`](#fn-librarypanelwithuid)
 * [`obj options`](#obj-options)
   * [`fn withDedupStrategy(value)`](#fn-optionswithdedupstrategy)
-  * [`fn withEnableLogDetails(value)`](#fn-optionswithenablelogdetails)
-  * [`fn withPrettifyLogMessage(value)`](#fn-optionswithprettifylogmessage)
-  * [`fn withShowCommonLabels(value)`](#fn-optionswithshowcommonlabels)
-  * [`fn withShowLabels(value)`](#fn-optionswithshowlabels)
-  * [`fn withShowTime(value)`](#fn-optionswithshowtime)
+  * [`fn withEnableLogDetails(value=true)`](#fn-optionswithenablelogdetails)
+  * [`fn withPrettifyLogMessage(value=true)`](#fn-optionswithprettifylogmessage)
+  * [`fn withShowCommonLabels(value=true)`](#fn-optionswithshowcommonlabels)
+  * [`fn withShowLabels(value=true)`](#fn-optionswithshowlabels)
+  * [`fn withShowTime(value=true)`](#fn-optionswithshowtime)
   * [`fn withSortOrder(value)`](#fn-optionswithsortorder)
-  * [`fn withWrapLogMessage(value)`](#fn-optionswithwraplogmessage)
+  * [`fn withWrapLogMessage(value=true)`](#fn-optionswithwraplogmessage)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.logs
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -182,7 +182,7 @@ Accepted values for `value` are "none", "exact", "numbers", "signature"
 #### fn options.withEnableLogDetails
 
 ```ts
-withEnableLogDetails(value)
+withEnableLogDetails(value=true)
 ```
 
 
@@ -190,7 +190,7 @@ withEnableLogDetails(value)
 #### fn options.withPrettifyLogMessage
 
 ```ts
-withPrettifyLogMessage(value)
+withPrettifyLogMessage(value=true)
 ```
 
 
@@ -198,7 +198,7 @@ withPrettifyLogMessage(value)
 #### fn options.withShowCommonLabels
 
 ```ts
-withShowCommonLabels(value)
+withShowCommonLabels(value=true)
 ```
 
 
@@ -206,7 +206,7 @@ withShowCommonLabels(value)
 #### fn options.withShowLabels
 
 ```ts
-withShowLabels(value)
+withShowLabels(value=true)
 ```
 
 
@@ -214,7 +214,7 @@ withShowLabels(value)
 #### fn options.withShowTime
 
 ```ts
-withShowTime(value)
+withShowTime(value=true)
 ```
 
 
@@ -232,7 +232,7 @@ Accepted values for `value` are "Descending", "Ascending"
 #### fn options.withWrapLogMessage
 
 ```ts
-withWrapLogMessage(value)
+withWrapLogMessage(value=true)
 ```
 
 
@@ -297,7 +297,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/logs/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.news
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -35,7 +35,7 @@ grafonnet.panel.news
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -112,7 +112,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -239,7 +239,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/news/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.nodeGraph
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,7 +48,7 @@ grafonnet.panel.nodeGraph
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -125,7 +125,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -341,7 +341,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/nodeGraph/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/index.md
@@ -22,12 +22,12 @@ grafonnet.panel.pieChart
       * [`fn withHideFrom(value)`](#fn-fieldconfigdefaultscustomwithhidefrom)
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.pieChart
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withValues(value)`](#fn-optionslegendwithvalues)
     * [`fn withValuesMixin(value)`](#fn-optionslegendwithvaluesmixin)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
@@ -65,7 +65,7 @@ grafonnet.panel.pieChart
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -79,7 +79,7 @@ grafonnet.panel.pieChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -173,7 +173,7 @@ TODO docs
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -181,7 +181,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -189,7 +189,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -208,7 +208,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -365,7 +365,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -400,7 +400,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -418,7 +418,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -434,7 +434,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -501,7 +501,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -608,7 +608,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/pieChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/row.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/row.md
@@ -5,7 +5,7 @@ grafonnet.panel.row
 ## Index
 
 * [`fn new(title)`](#fn-new)
-* [`fn withCollapsed(value=false)`](#fn-withcollapsed)
+* [`fn withCollapsed(value=true)`](#fn-withcollapsed)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withDatasourceMixin(value)`](#fn-withdatasourcemixin)
 * [`fn withGridPos(value)`](#fn-withgridpos)
@@ -21,7 +21,7 @@ grafonnet.panel.row
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -39,7 +39,7 @@ Creates a new row panel with a title.
 ### fn withCollapsed
 
 ```ts
-withCollapsed(value=false)
+withCollapsed(value=true)
 ```
 
 
@@ -157,7 +157,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.stat
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -40,7 +40,7 @@ grafonnet.panel.stat
     * [`fn withCalcsMixin(value)`](#fn-optionsreduceoptionswithcalcsmixin)
     * [`fn withFields(value)`](#fn-optionsreduceoptionswithfields)
     * [`fn withLimit(value)`](#fn-optionsreduceoptionswithlimit)
-    * [`fn withValues(value)`](#fn-optionsreduceoptionswithvalues)
+    * [`fn withValues(value=true)`](#fn-optionsreduceoptionswithvalues)
   * [`obj text`](#obj-optionstext)
     * [`fn withTitleSize(value)`](#fn-optionstextwithtitlesize)
     * [`fn withValueSize(value)`](#fn-optionstextwithvaluesize)
@@ -51,7 +51,7 @@ grafonnet.panel.stat
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -128,7 +128,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -299,7 +299,7 @@ if showing all values limit
 ##### fn options.reduceOptions.withValues
 
 ```ts
-withValues(value)
+withValues(value=true)
 ```
 
 If true show each row value
@@ -383,7 +383,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stat/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.stateTimeline
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=0)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -48,15 +48,15 @@ grafonnet.panel.stateTimeline
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -68,7 +68,7 @@ grafonnet.panel.stateTimeline
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -178,7 +178,7 @@ withLineWidth(value=0)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -186,7 +186,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -194,7 +194,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -213,7 +213,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -354,7 +354,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -389,7 +389,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -407,7 +407,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -423,7 +423,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -519,7 +519,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/stateTimeline/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/index.md
@@ -24,12 +24,12 @@ grafonnet.panel.statusHistory
       * [`fn withHideFromMixin(value)`](#fn-fieldconfigdefaultscustomwithhidefrommixin)
       * [`fn withLineWidth(value=1)`](#fn-fieldconfigdefaultscustomwithlinewidth)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -47,15 +47,15 @@ grafonnet.panel.statusHistory
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -67,7 +67,7 @@ grafonnet.panel.statusHistory
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -177,7 +177,7 @@ withLineWidth(value=1)
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -185,7 +185,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -193,7 +193,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -212,7 +212,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -343,7 +343,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -378,7 +378,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -396,7 +396,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -412,7 +412,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -508,7 +508,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/statusHistory/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.table
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -31,22 +31,22 @@ grafonnet.panel.table
   * [`fn withFooterMixin(value={"countRows": false,"reducer": [],"show": false})`](#fn-optionswithfootermixin)
   * [`fn withFrameIndex(value=0)`](#fn-optionswithframeindex)
   * [`fn withShowHeader(value=true)`](#fn-optionswithshowheader)
-  * [`fn withShowTypeIcons(value=false)`](#fn-optionswithshowtypeicons)
+  * [`fn withShowTypeIcons(value=true)`](#fn-optionswithshowtypeicons)
   * [`fn withSortBy(value)`](#fn-optionswithsortby)
   * [`fn withSortByMixin(value)`](#fn-optionswithsortbymixin)
   * [`obj footer`](#obj-optionsfooter)
     * [`fn withTableFooterOptions(value)`](#fn-optionsfooterwithtablefooteroptions)
     * [`fn withTableFooterOptionsMixin(value)`](#fn-optionsfooterwithtablefooteroptionsmixin)
     * [`obj TableFooterOptions`](#obj-optionsfootertablefooteroptions)
-      * [`fn withCountRows(value)`](#fn-optionsfootertablefooteroptionswithcountrows)
-      * [`fn withEnablePagination(value)`](#fn-optionsfootertablefooteroptionswithenablepagination)
+      * [`fn withCountRows(value=true)`](#fn-optionsfootertablefooteroptionswithcountrows)
+      * [`fn withEnablePagination(value=true)`](#fn-optionsfootertablefooteroptionswithenablepagination)
       * [`fn withFields(value)`](#fn-optionsfootertablefooteroptionswithfields)
       * [`fn withFieldsMixin(value)`](#fn-optionsfootertablefooteroptionswithfieldsmixin)
       * [`fn withReducer(value)`](#fn-optionsfootertablefooteroptionswithreducer)
       * [`fn withReducerMixin(value)`](#fn-optionsfootertablefooteroptionswithreducermixin)
-      * [`fn withShow(value)`](#fn-optionsfootertablefooteroptionswithshow)
+      * [`fn withShow(value=true)`](#fn-optionsfootertablefooteroptionswithshow)
   * [`obj sortBy`](#obj-optionssortby)
-    * [`fn withDesc(value)`](#fn-optionssortbywithdesc)
+    * [`fn withDesc(value=true)`](#fn-optionssortbywithdesc)
     * [`fn withDisplayName(value)`](#fn-optionssortbywithdisplayname)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
@@ -55,7 +55,7 @@ grafonnet.panel.table
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -132,7 +132,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -228,7 +228,7 @@ Controls whether the panel should show the header
 #### fn options.withShowTypeIcons
 
 ```ts
-withShowTypeIcons(value=false)
+withShowTypeIcons(value=true)
 ```
 
 Controls whether the header should show icons for the column types
@@ -274,7 +274,7 @@ Footer options
 ###### fn options.footer.TableFooterOptions.withCountRows
 
 ```ts
-withCountRows(value)
+withCountRows(value=true)
 ```
 
 
@@ -282,7 +282,7 @@ withCountRows(value)
 ###### fn options.footer.TableFooterOptions.withEnablePagination
 
 ```ts
-withEnablePagination(value)
+withEnablePagination(value=true)
 ```
 
 
@@ -322,7 +322,7 @@ withReducerMixin(value)
 ###### fn options.footer.TableFooterOptions.withShow
 
 ```ts
-withShow(value)
+withShow(value=true)
 ```
 
 
@@ -333,7 +333,7 @@ withShow(value)
 ##### fn options.sortBy.withDesc
 
 ```ts
-withDesc(value)
+withDesc(value=true)
 ```
 
 Flag used to indicate descending sort order
@@ -406,7 +406,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/table/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.text
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -32,8 +32,8 @@ grafonnet.panel.text
   * [`fn withMode(value)`](#fn-optionswithmode)
   * [`obj code`](#obj-optionscode)
     * [`fn withLanguage(value="plaintext")`](#fn-optionscodewithlanguage)
-    * [`fn withShowLineNumbers(value=false)`](#fn-optionscodewithshowlinenumbers)
-    * [`fn withShowMiniMap(value=false)`](#fn-optionscodewithshowminimap)
+    * [`fn withShowLineNumbers(value=true)`](#fn-optionscodewithshowlinenumbers)
+    * [`fn withShowMiniMap(value=true)`](#fn-optionscodewithshowminimap)
 * [`obj panelOptions`](#obj-paneloptions)
   * [`fn withDescription(value)`](#fn-paneloptionswithdescription)
   * [`fn withLinks(value)`](#fn-paneloptionswithlinks)
@@ -41,7 +41,7 @@ grafonnet.panel.text
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -118,7 +118,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -219,7 +219,7 @@ Accepted values for `value` are "plaintext", "yaml", "xml", "typescript", "sql",
 ##### fn options.code.withShowLineNumbers
 
 ```ts
-withShowLineNumbers(value=false)
+withShowLineNumbers(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withShowLineNumbers(value=false)
 ##### fn options.code.withShowMiniMap
 
 ```ts
-withShowMiniMap(value=false)
+withShowMiniMap(value=true)
 ```
 
 
@@ -292,7 +292,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/text/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/index.md
@@ -19,9 +19,9 @@ grafonnet.panel.timeSeries
 * [`obj fieldConfig`](#obj-fieldconfig)
   * [`obj defaults`](#obj-fieldconfigdefaults)
     * [`obj custom`](#obj-fieldconfigdefaultscustom)
-      * [`fn withAxisCenteredZero(value)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
+      * [`fn withAxisCenteredZero(value=true)`](#fn-fieldconfigdefaultscustomwithaxiscenteredzero)
       * [`fn withAxisColorMode(value)`](#fn-fieldconfigdefaultscustomwithaxiscolormode)
-      * [`fn withAxisGridShow(value)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
+      * [`fn withAxisGridShow(value=true)`](#fn-fieldconfigdefaultscustomwithaxisgridshow)
       * [`fn withAxisLabel(value)`](#fn-fieldconfigdefaultscustomwithaxislabel)
       * [`fn withAxisPlacement(value)`](#fn-fieldconfigdefaultscustomwithaxisplacement)
       * [`fn withAxisSoftMax(value)`](#fn-fieldconfigdefaultscustomwithaxissoftmax)
@@ -56,9 +56,9 @@ grafonnet.panel.timeSeries
       * [`fn withThresholdsStyleMixin(value)`](#fn-fieldconfigdefaultscustomwiththresholdsstylemixin)
       * [`fn withTransform(value)`](#fn-fieldconfigdefaultscustomwithtransform)
       * [`obj hideFrom`](#obj-fieldconfigdefaultscustomhidefrom)
-        * [`fn withLegend(value)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
-        * [`fn withTooltip(value)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
-        * [`fn withViz(value)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
+        * [`fn withLegend(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithlegend)
+        * [`fn withTooltip(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithtooltip)
+        * [`fn withViz(value=true)`](#fn-fieldconfigdefaultscustomhidefromwithviz)
       * [`obj lineStyle`](#obj-fieldconfigdefaultscustomlinestyle)
         * [`fn withDash(value)`](#fn-fieldconfigdefaultscustomlinestylewithdash)
         * [`fn withDashMixin(value)`](#fn-fieldconfigdefaultscustomlinestylewithdashmixin)
@@ -74,7 +74,7 @@ grafonnet.panel.timeSeries
         * [`fn withMode(value)`](#fn-fieldconfigdefaultscustomthresholdsstylewithmode)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -89,15 +89,15 @@ grafonnet.panel.timeSeries
   * [`fn withTooltip(value)`](#fn-optionswithtooltip)
   * [`fn withTooltipMixin(value)`](#fn-optionswithtooltipmixin)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj tooltip`](#obj-optionstooltip)
     * [`fn withMode(value)`](#fn-optionstooltipwithmode)
@@ -109,7 +109,7 @@ grafonnet.panel.timeSeries
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -184,7 +184,7 @@ withUid(value)
 ###### fn fieldConfig.defaults.custom.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -202,7 +202,7 @@ Accepted values for `value` are "text", "series"
 ###### fn fieldConfig.defaults.custom.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -495,7 +495,7 @@ Accepted values for `value` are "constant", "negative-Y"
 ####### fn fieldConfig.defaults.custom.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -503,7 +503,7 @@ withLegend(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -511,7 +511,7 @@ withTooltip(value)
 ####### fn fieldConfig.defaults.custom.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -622,7 +622,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -727,7 +727,7 @@ TODO docs
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -762,7 +762,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -780,7 +780,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -796,7 +796,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -892,7 +892,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/timeSeries/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/index.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/index.md
@@ -18,7 +18,7 @@ grafonnet.panel.xyChart
   * [`fn withUid(value)`](#fn-datasourcewithuid)
 * [`obj gridPos`](#obj-gridpos)
   * [`fn withH(value=9)`](#fn-gridposwithh)
-  * [`fn withStatic(value)`](#fn-gridposwithstatic)
+  * [`fn withStatic(value=true)`](#fn-gridposwithstatic)
   * [`fn withW(value=12)`](#fn-gridposwithw)
   * [`fn withX(value=0)`](#fn-gridposwithx)
   * [`fn withY(value=0)`](#fn-gridposwithy)
@@ -41,20 +41,20 @@ grafonnet.panel.xyChart
     * [`fn withFrame(value)`](#fn-optionsdimswithframe)
     * [`fn withX(value)`](#fn-optionsdimswithx)
   * [`obj legend`](#obj-optionslegend)
-    * [`fn withAsTable(value)`](#fn-optionslegendwithastable)
+    * [`fn withAsTable(value=true)`](#fn-optionslegendwithastable)
     * [`fn withCalcs(value)`](#fn-optionslegendwithcalcs)
     * [`fn withCalcsMixin(value)`](#fn-optionslegendwithcalcsmixin)
     * [`fn withDisplayMode(value)`](#fn-optionslegendwithdisplaymode)
-    * [`fn withIsVisible(value)`](#fn-optionslegendwithisvisible)
+    * [`fn withIsVisible(value=true)`](#fn-optionslegendwithisvisible)
     * [`fn withPlacement(value)`](#fn-optionslegendwithplacement)
-    * [`fn withShowLegend(value)`](#fn-optionslegendwithshowlegend)
+    * [`fn withShowLegend(value=true)`](#fn-optionslegendwithshowlegend)
     * [`fn withSortBy(value)`](#fn-optionslegendwithsortby)
-    * [`fn withSortDesc(value)`](#fn-optionslegendwithsortdesc)
+    * [`fn withSortDesc(value=true)`](#fn-optionslegendwithsortdesc)
     * [`fn withWidth(value)`](#fn-optionslegendwithwidth)
   * [`obj series`](#obj-optionsseries)
-    * [`fn withAxisCenteredZero(value)`](#fn-optionsserieswithaxiscenteredzero)
+    * [`fn withAxisCenteredZero(value=true)`](#fn-optionsserieswithaxiscenteredzero)
     * [`fn withAxisColorMode(value)`](#fn-optionsserieswithaxiscolormode)
-    * [`fn withAxisGridShow(value)`](#fn-optionsserieswithaxisgridshow)
+    * [`fn withAxisGridShow(value=true)`](#fn-optionsserieswithaxisgridshow)
     * [`fn withAxisLabel(value)`](#fn-optionsserieswithaxislabel)
     * [`fn withAxisPlacement(value)`](#fn-optionsserieswithaxisplacement)
     * [`fn withAxisSoftMax(value)`](#fn-optionsserieswithaxissoftmax)
@@ -81,9 +81,9 @@ grafonnet.panel.xyChart
     * [`fn withX(value)`](#fn-optionsserieswithx)
     * [`fn withY(value)`](#fn-optionsserieswithy)
     * [`obj hideFrom`](#obj-optionsserieshidefrom)
-      * [`fn withLegend(value)`](#fn-optionsserieshidefromwithlegend)
-      * [`fn withTooltip(value)`](#fn-optionsserieshidefromwithtooltip)
-      * [`fn withViz(value)`](#fn-optionsserieshidefromwithviz)
+      * [`fn withLegend(value=true)`](#fn-optionsserieshidefromwithlegend)
+      * [`fn withTooltip(value=true)`](#fn-optionsserieshidefromwithtooltip)
+      * [`fn withViz(value=true)`](#fn-optionsserieshidefromwithviz)
     * [`obj labelValue`](#obj-optionsserieslabelvalue)
       * [`fn withField(value)`](#fn-optionsserieslabelvaluewithfield)
       * [`fn withFixed(value)`](#fn-optionsserieslabelvaluewithfixed)
@@ -121,7 +121,7 @@ grafonnet.panel.xyChart
   * [`fn withRepeat(value)`](#fn-paneloptionswithrepeat)
   * [`fn withRepeatDirection(value="h")`](#fn-paneloptionswithrepeatdirection)
   * [`fn withTitle(value)`](#fn-paneloptionswithtitle)
-  * [`fn withTransparent(value=false)`](#fn-paneloptionswithtransparent)
+  * [`fn withTransparent(value=true)`](#fn-paneloptionswithtransparent)
 * [`obj queryOptions`](#obj-queryoptions)
   * [`fn withDatasource(value)`](#fn-queryoptionswithdatasource)
   * [`fn withDatasourceMixin(value)`](#fn-queryoptionswithdatasourcemixin)
@@ -198,7 +198,7 @@ Panel
 #### fn gridPos.withStatic
 
 ```ts
-withStatic(value)
+withStatic(value=true)
 ```
 
 true if fixed
@@ -364,7 +364,7 @@ withX(value)
 ##### fn options.legend.withAsTable
 
 ```ts
-withAsTable(value)
+withAsTable(value=true)
 ```
 
 
@@ -399,7 +399,7 @@ Accepted values for `value` are "list", "table", "hidden"
 ##### fn options.legend.withIsVisible
 
 ```ts
-withIsVisible(value)
+withIsVisible(value=true)
 ```
 
 
@@ -417,7 +417,7 @@ Accepted values for `value` are "bottom", "right"
 ##### fn options.legend.withShowLegend
 
 ```ts
-withShowLegend(value)
+withShowLegend(value=true)
 ```
 
 
@@ -433,7 +433,7 @@ withSortBy(value)
 ##### fn options.legend.withSortDesc
 
 ```ts
-withSortDesc(value)
+withSortDesc(value=true)
 ```
 
 
@@ -452,7 +452,7 @@ withWidth(value)
 ##### fn options.series.withAxisCenteredZero
 
 ```ts
-withAxisCenteredZero(value)
+withAxisCenteredZero(value=true)
 ```
 
 
@@ -470,7 +470,7 @@ Accepted values for `value` are "text", "series"
 ##### fn options.series.withAxisGridShow
 
 ```ts
-withAxisGridShow(value)
+withAxisGridShow(value=true)
 ```
 
 
@@ -687,7 +687,7 @@ withY(value)
 ###### fn options.series.hideFrom.withLegend
 
 ```ts
-withLegend(value)
+withLegend(value=true)
 ```
 
 
@@ -695,7 +695,7 @@ withLegend(value)
 ###### fn options.series.hideFrom.withTooltip
 
 ```ts
-withTooltip(value)
+withTooltip(value=true)
 ```
 
 
@@ -703,7 +703,7 @@ withTooltip(value)
 ###### fn options.series.hideFrom.withViz
 
 ```ts
-withViz(value)
+withViz(value=true)
 ```
 
 
@@ -983,7 +983,7 @@ Panel title.
 #### fn panelOptions.withTransparent
 
 ```ts
-withTransparent(value=false)
+withTransparent(value=true)
 ```
 
 Whether to display the panel without a background.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/link.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/link.md
@@ -4,13 +4,13 @@
 
 ## Index
 
-* [`fn withAsDropdown(value=false)`](#fn-withasdropdown)
+* [`fn withAsDropdown(value=true)`](#fn-withasdropdown)
 * [`fn withIcon(value)`](#fn-withicon)
-* [`fn withIncludeVars(value=false)`](#fn-withincludevars)
-* [`fn withKeepTime(value=false)`](#fn-withkeeptime)
+* [`fn withIncludeVars(value=true)`](#fn-withincludevars)
+* [`fn withKeepTime(value=true)`](#fn-withkeeptime)
 * [`fn withTags(value)`](#fn-withtags)
 * [`fn withTagsMixin(value)`](#fn-withtagsmixin)
-* [`fn withTargetBlank(value=false)`](#fn-withtargetblank)
+* [`fn withTargetBlank(value=true)`](#fn-withtargetblank)
 * [`fn withTitle(value)`](#fn-withtitle)
 * [`fn withTooltip(value)`](#fn-withtooltip)
 * [`fn withType(value)`](#fn-withtype)
@@ -21,7 +21,7 @@
 ### fn withAsDropdown
 
 ```ts
-withAsDropdown(value=false)
+withAsDropdown(value=true)
 ```
 
 
@@ -37,7 +37,7 @@ withIcon(value)
 ### fn withIncludeVars
 
 ```ts
-withIncludeVars(value=false)
+withIncludeVars(value=true)
 ```
 
 
@@ -45,7 +45,7 @@ withIncludeVars(value=false)
 ### fn withKeepTime
 
 ```ts
-withKeepTime(value=false)
+withKeepTime(value=true)
 ```
 
 
@@ -69,7 +69,7 @@ withTagsMixin(value)
 ### fn withTargetBlank
 
 ```ts
-withTargetBlank(value=false)
+withTargetBlank(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/transformation.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/panel/xyChart/transformation.md
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [`fn withDisabled(value)`](#fn-withdisabled)
+* [`fn withDisabled(value=true)`](#fn-withdisabled)
 * [`fn withFilter(value)`](#fn-withfilter)
 * [`fn withFilterMixin(value)`](#fn-withfiltermixin)
 * [`fn withId(value)`](#fn-withid)
@@ -18,7 +18,7 @@
 ### fn withDisabled
 
 ```ts
-withDisabled(value)
+withDisabled(value=true)
 ```
 
 Disabled transformations are skipped

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/publicdashboard.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/publicdashboard.md
@@ -5,10 +5,10 @@ grafonnet.publicdashboard
 ## Index
 
 * [`fn withAccessToken(value)`](#fn-withaccesstoken)
-* [`fn withAnnotationsEnabled(value)`](#fn-withannotationsenabled)
+* [`fn withAnnotationsEnabled(value=true)`](#fn-withannotationsenabled)
 * [`fn withDashboardUid(value)`](#fn-withdashboarduid)
-* [`fn withIsEnabled(value)`](#fn-withisenabled)
-* [`fn withTimeSelectionEnabled(value)`](#fn-withtimeselectionenabled)
+* [`fn withIsEnabled(value=true)`](#fn-withisenabled)
+* [`fn withTimeSelectionEnabled(value=true)`](#fn-withtimeselectionenabled)
 * [`fn withUid(value)`](#fn-withuid)
 
 ## Fields
@@ -24,7 +24,7 @@ Unique public access token
 ### fn withAnnotationsEnabled
 
 ```ts
-withAnnotationsEnabled(value)
+withAnnotationsEnabled(value=true)
 ```
 
 Flag that indicates if annotations are enabled
@@ -40,7 +40,7 @@ Dashboard unique identifier referenced by this public dashboard
 ### fn withIsEnabled
 
 ```ts
-withIsEnabled(value)
+withIsEnabled(value=true)
 ```
 
 Flag that indicates if the public dashboard is enabled
@@ -48,7 +48,7 @@ Flag that indicates if the public dashboard is enabled
 ### fn withTimeSelectionEnabled
 
 ```ts
-withTimeSelectionEnabled(value)
+withTimeSelectionEnabled(value=true)
 ```
 
 Flag that indicates if the time range picker is enabled

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/azureMonitor.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/azureMonitor.md
@@ -13,7 +13,7 @@ grafonnet.query.azureMonitor
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGrafanaTemplateVariableFn(value)`](#fn-withgrafanatemplatevariablefn)
 * [`fn withGrafanaTemplateVariableFnMixin(value)`](#fn-withgrafanatemplatevariablefnmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withNamespace(value)`](#fn-withnamespace)
 * [`fn withQueryType(value)`](#fn-withquerytype)
 * [`fn withRefId(value)`](#fn-withrefid)
@@ -217,7 +217,7 @@ withGrafanaTemplateVariableFnMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/cloudWatch.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/cloudWatch.md
@@ -11,12 +11,12 @@ grafonnet.query.cloudWatch
   * [`fn withDatasource(value)`](#fn-cloudwatchannotationquerywithdatasource)
   * [`fn withDimensions(value)`](#fn-cloudwatchannotationquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchannotationquerywithdimensionsmixin)
-  * [`fn withHide(value)`](#fn-cloudwatchannotationquerywithhide)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchannotationquerywithmatchexact)
+  * [`fn withHide(value=true)`](#fn-cloudwatchannotationquerywithhide)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchannotationquerywithmatchexact)
   * [`fn withMetricName(value)`](#fn-cloudwatchannotationquerywithmetricname)
   * [`fn withNamespace(value)`](#fn-cloudwatchannotationquerywithnamespace)
   * [`fn withPeriod(value)`](#fn-cloudwatchannotationquerywithperiod)
-  * [`fn withPrefixMatching(value)`](#fn-cloudwatchannotationquerywithprefixmatching)
+  * [`fn withPrefixMatching(value=true)`](#fn-cloudwatchannotationquerywithprefixmatching)
   * [`fn withQueryMode(value)`](#fn-cloudwatchannotationquerywithquerymode)
   * [`fn withQueryType(value)`](#fn-cloudwatchannotationquerywithquerytype)
   * [`fn withRefId(value)`](#fn-cloudwatchannotationquerywithrefid)
@@ -27,7 +27,7 @@ grafonnet.query.cloudWatch
 * [`obj CloudWatchLogsQuery`](#obj-cloudwatchlogsquery)
   * [`fn withDatasource(value)`](#fn-cloudwatchlogsquerywithdatasource)
   * [`fn withExpression(value)`](#fn-cloudwatchlogsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchlogsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchlogsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchlogsquerywithid)
   * [`fn withLogGroupNames(value)`](#fn-cloudwatchlogsquerywithloggroupnames)
   * [`fn withLogGroupNamesMixin(value)`](#fn-cloudwatchlogsquerywithloggroupnamesmixin)
@@ -51,10 +51,10 @@ grafonnet.query.cloudWatch
   * [`fn withDimensions(value)`](#fn-cloudwatchmetricsquerywithdimensions)
   * [`fn withDimensionsMixin(value)`](#fn-cloudwatchmetricsquerywithdimensionsmixin)
   * [`fn withExpression(value)`](#fn-cloudwatchmetricsquerywithexpression)
-  * [`fn withHide(value)`](#fn-cloudwatchmetricsquerywithhide)
+  * [`fn withHide(value=true)`](#fn-cloudwatchmetricsquerywithhide)
   * [`fn withId(value)`](#fn-cloudwatchmetricsquerywithid)
   * [`fn withLabel(value)`](#fn-cloudwatchmetricsquerywithlabel)
-  * [`fn withMatchExact(value)`](#fn-cloudwatchmetricsquerywithmatchexact)
+  * [`fn withMatchExact(value=true)`](#fn-cloudwatchmetricsquerywithmatchexact)
   * [`fn withMetricEditorMode(value)`](#fn-cloudwatchmetricsquerywithmetriceditormode)
   * [`fn withMetricName(value)`](#fn-cloudwatchmetricsquerywithmetricname)
   * [`fn withMetricQueryType(value)`](#fn-cloudwatchmetricsquerywithmetricquerytype)
@@ -185,7 +185,7 @@ withDimensionsMixin(value)
 #### fn CloudWatchAnnotationQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -195,7 +195,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 #### fn CloudWatchAnnotationQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 
@@ -227,7 +227,7 @@ withPeriod(value)
 #### fn CloudWatchAnnotationQuery.withPrefixMatching
 
 ```ts
-withPrefixMatching(value)
+withPrefixMatching(value=true)
 ```
 
 
@@ -318,7 +318,7 @@ withExpression(value)
 #### fn CloudWatchLogsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -510,7 +510,7 @@ Math expression query
 #### fn CloudWatchMetricsQuery.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -536,7 +536,7 @@ withLabel(value)
 #### fn CloudWatchMetricsQuery.withMatchExact
 
 ```ts
-withMatchExact(value)
+withMatchExact(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/elasticsearch.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/elasticsearch.md
@@ -8,7 +8,7 @@ grafonnet.query.elasticsearch
 * [`fn withBucketAggs(value)`](#fn-withbucketaggs)
 * [`fn withBucketAggsMixin(value)`](#fn-withbucketaggsmixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withMetrics(value)`](#fn-withmetrics)
 * [`fn withMetricsMixin(value)`](#fn-withmetricsmixin)
 * [`fn withQuery(value)`](#fn-withquery)
@@ -76,13 +76,13 @@ grafonnet.query.elasticsearch
       * [`fn withSize(value)`](#fn-bucketaggstermssettingswithsize)
 * [`obj metrics`](#obj-metrics)
   * [`obj Count`](#obj-metricscount)
-    * [`fn withHide(value)`](#fn-metricscountwithhide)
+    * [`fn withHide(value=true)`](#fn-metricscountwithhide)
     * [`fn withId(value)`](#fn-metricscountwithid)
     * [`fn withType(value)`](#fn-metricscountwithtype)
   * [`obj MetricAggregationWithSettings`](#obj-metricsmetricaggregationwithsettings)
     * [`obj Average`](#obj-metricsmetricaggregationwithsettingsaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsaveragewithsettingsmixin)
@@ -94,7 +94,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsaveragesettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsaveragesettingsscriptwithinline)
     * [`obj BucketScript`](#obj-metricsmetricaggregationwithsettingsbucketscript)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptwithpipelinevariablesmixin)
@@ -111,7 +111,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricsmetricaggregationwithsettingscumulativesum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumwithsettings)
@@ -121,7 +121,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricsmetricaggregationwithsettingscumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricsmetricaggregationwithsettingsderivative)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsderivativewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsderivativewithsettings)
@@ -131,7 +131,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsderivativesettingswithunit)
     * [`obj ExtendedStats`](#obj-metricsmetricaggregationwithsettingsextendedstats)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithid)
       * [`fn withMeta(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmeta)
       * [`fn withMetaMixin(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatswithmetamixin)
@@ -146,7 +146,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingsextendedstatssettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsextendedstatssettingsscriptwithinline)
     * [`obj Logs`](#obj-metricsmetricaggregationwithsettingslogs)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingslogswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingslogswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingslogswithsettingsmixin)
@@ -155,7 +155,7 @@ grafonnet.query.elasticsearch
         * [`fn withLimit(value)`](#fn-metricsmetricaggregationwithsettingslogssettingswithlimit)
     * [`obj Max`](#obj-metricsmetricaggregationwithsettingsmax)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmaxwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsmaxwithsettingsmixin)
@@ -168,7 +168,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmaxsettingsscriptwithinline)
     * [`obj Min`](#obj-metricsmetricaggregationwithsettingsmin)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsminwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsminwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsminwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsminwithsettingsmixin)
@@ -181,7 +181,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsminsettingsscriptwithinline)
     * [`obj MovingAverage`](#obj-metricsmetricaggregationwithsettingsmovingaverage)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithsettings)
@@ -189,7 +189,7 @@ grafonnet.query.elasticsearch
       * [`fn withType(value)`](#fn-metricsmetricaggregationwithsettingsmovingaveragewithtype)
     * [`obj MovingFunction`](#obj-metricsmetricaggregationwithsettingsmovingfunction)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionwithsettings)
@@ -204,7 +204,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingsmovingfunctionsettingsscriptwithinline)
     * [`obj Percentiles`](#obj-metricsmetricaggregationwithsettingspercentiles)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingspercentileswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingspercentileswithsettingsmixin)
@@ -219,7 +219,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingspercentilessettingsscriptwithinline)
     * [`obj Rate`](#obj-metricsmetricaggregationwithsettingsrate)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsratewithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsratewithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsratewithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsratewithsettingsmixin)
@@ -228,7 +228,7 @@ grafonnet.query.elasticsearch
         * [`fn withMode(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithmode)
         * [`fn withUnit(value)`](#fn-metricsmetricaggregationwithsettingsratesettingswithunit)
     * [`obj RawData`](#obj-metricsmetricaggregationwithsettingsrawdata)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdatawithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdatawithsettingsmixin)
@@ -236,7 +236,7 @@ grafonnet.query.elasticsearch
       * [`obj settings`](#obj-metricsmetricaggregationwithsettingsrawdatasettings)
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdatasettingswithsize)
     * [`obj RawDocument`](#obj-metricsmetricaggregationwithsettingsrawdocument)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentwithsettingsmixin)
@@ -245,7 +245,7 @@ grafonnet.query.elasticsearch
         * [`fn withSize(value)`](#fn-metricsmetricaggregationwithsettingsrawdocumentsettingswithsize)
     * [`obj SerialDiff`](#obj-metricsmetricaggregationwithsettingsserialdiff)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffwithsettings)
@@ -255,7 +255,7 @@ grafonnet.query.elasticsearch
         * [`fn withLag(value)`](#fn-metricsmetricaggregationwithsettingsserialdiffsettingswithlag)
     * [`obj Sum`](#obj-metricsmetricaggregationwithsettingssum)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingssumwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingssumwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingssumwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingssumwithsettingsmixin)
@@ -267,7 +267,7 @@ grafonnet.query.elasticsearch
         * [`obj script`](#obj-metricsmetricaggregationwithsettingssumsettingsscript)
           * [`fn withInline(value)`](#fn-metricsmetricaggregationwithsettingssumsettingsscriptwithinline)
     * [`obj TopMetrics`](#obj-metricsmetricaggregationwithsettingstopmetrics)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingstopmetricswithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingstopmetricswithsettingsmixin)
@@ -279,7 +279,7 @@ grafonnet.query.elasticsearch
         * [`fn withOrderBy(value)`](#fn-metricsmetricaggregationwithsettingstopmetricssettingswithorderby)
     * [`obj UniqueCount`](#obj-metricsmetricaggregationwithsettingsuniquecount)
       * [`fn withField(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithfield)
-      * [`fn withHide(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
+      * [`fn withHide(value=true)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithhide)
       * [`fn withId(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithid)
       * [`fn withSettings(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettings)
       * [`fn withSettingsMixin(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountwithsettingsmixin)
@@ -289,7 +289,7 @@ grafonnet.query.elasticsearch
         * [`fn withPrecisionThreshold(value)`](#fn-metricsmetricaggregationwithsettingsuniquecountsettingswithprecisionthreshold)
   * [`obj PipelineMetricAggregation`](#obj-metricspipelinemetricaggregation)
     * [`obj BucketScript`](#obj-metricspipelinemetricaggregationbucketscript)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationbucketscriptwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithid)
       * [`fn withPipelineVariables(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariables)
       * [`fn withPipelineVariablesMixin(value)`](#fn-metricspipelinemetricaggregationbucketscriptwithpipelinevariablesmixin)
@@ -306,7 +306,7 @@ grafonnet.query.elasticsearch
           * [`fn withInline(value)`](#fn-metricspipelinemetricaggregationbucketscriptsettingsscriptwithinline)
     * [`obj CumulativeSum`](#obj-metricspipelinemetricaggregationcumulativesum)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationcumulativesumwithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationcumulativesumwithsettings)
@@ -316,7 +316,7 @@ grafonnet.query.elasticsearch
         * [`fn withFormat(value)`](#fn-metricspipelinemetricaggregationcumulativesumsettingswithformat)
     * [`obj Derivative`](#obj-metricspipelinemetricaggregationderivative)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationderivativewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationderivativewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationderivativewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationderivativewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationderivativewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationderivativewithsettings)
@@ -326,7 +326,7 @@ grafonnet.query.elasticsearch
         * [`fn withUnit(value)`](#fn-metricspipelinemetricaggregationderivativesettingswithunit)
     * [`obj MovingAverage`](#obj-metricspipelinemetricaggregationmovingaverage)
       * [`fn withField(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithfield)
-      * [`fn withHide(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
+      * [`fn withHide(value=true)`](#fn-metricspipelinemetricaggregationmovingaveragewithhide)
       * [`fn withId(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithid)
       * [`fn withPipelineAgg(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithpipelineagg)
       * [`fn withSettings(value)`](#fn-metricspipelinemetricaggregationmovingaveragewithsettings)
@@ -373,7 +373,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -849,7 +849,7 @@ withSize(value)
 ##### fn metrics.Count.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -887,7 +887,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Average.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -968,7 +968,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1084,7 +1084,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1154,7 +1154,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1224,7 +1224,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.ExtendedStats.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1329,7 +1329,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.Logs.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1391,7 +1391,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Max.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1480,7 +1480,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Min.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1569,7 +1569,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1628,7 +1628,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.MovingFunction.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1733,7 +1733,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Percentiles.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1838,7 +1838,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Rate.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1900,7 +1900,7 @@ withUnit(value)
 ###### fn metrics.MetricAggregationWithSettings.RawData.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -1954,7 +1954,7 @@ withSize(value)
 ###### fn metrics.MetricAggregationWithSettings.RawDocument.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2016,7 +2016,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.SerialDiff.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2086,7 +2086,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.Sum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2167,7 +2167,7 @@ withInline(value)
 ###### fn metrics.MetricAggregationWithSettings.TopMetrics.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2253,7 +2253,7 @@ withField(value)
 ###### fn metrics.MetricAggregationWithSettings.UniqueCount.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2318,7 +2318,7 @@ withPrecisionThreshold(value)
 ###### fn metrics.PipelineMetricAggregation.BucketScript.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2434,7 +2434,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.CumulativeSum.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2504,7 +2504,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.Derivative.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 
@@ -2574,7 +2574,7 @@ withField(value)
 ###### fn metrics.PipelineMetricAggregation.MovingAverage.withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/loki.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/loki.md
@@ -8,12 +8,12 @@ grafonnet.query.loki
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
 * [`fn withExpr(value)`](#fn-withexpr)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withMaxLines(value)`](#fn-withmaxlines)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 * [`fn withResolution(value)`](#fn-withresolution)
 
@@ -56,7 +56,7 @@ The LogQL query.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -66,7 +66,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 @deprecated, now use queryType.
@@ -99,7 +99,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 @deprecated, now use queryType.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/parca.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/parca.md
@@ -5,7 +5,7 @@ grafonnet.query.parca
 ## Index
 
 * [`fn withDatasource(value)`](#fn-withdatasource)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -27,7 +27,7 @@ TODO this shouldn't be unknown but DataSourceRef | null
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/phlare.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/phlare.md
@@ -7,7 +7,7 @@ grafonnet.query.phlare
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withGroupBy(value)`](#fn-withgroupby)
 * [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabelSelector(value="{}")`](#fn-withlabelselector)
 * [`fn withProfileTypeId(value)`](#fn-withprofiletypeid)
 * [`fn withQueryType(value)`](#fn-withquerytype)
@@ -45,7 +45,7 @@ Allows to group the results.
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/prometheus.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/prometheus.md
@@ -7,15 +7,15 @@ grafonnet.query.prometheus
 * [`fn new(datasource, expr)`](#fn-new)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withEditorMode(value)`](#fn-witheditormode)
-* [`fn withExemplar(value)`](#fn-withexemplar)
+* [`fn withExemplar(value=true)`](#fn-withexemplar)
 * [`fn withExpr(value)`](#fn-withexpr)
 * [`fn withFormat(value)`](#fn-withformat)
-* [`fn withHide(value)`](#fn-withhide)
-* [`fn withInstant(value)`](#fn-withinstant)
+* [`fn withHide(value=true)`](#fn-withhide)
+* [`fn withInstant(value=true)`](#fn-withinstant)
 * [`fn withIntervalFactor(value)`](#fn-withintervalfactor)
 * [`fn withLegendFormat(value)`](#fn-withlegendformat)
 * [`fn withQueryType(value)`](#fn-withquerytype)
-* [`fn withRange(value)`](#fn-withrange)
+* [`fn withRange(value=true)`](#fn-withrange)
 * [`fn withRefId(value)`](#fn-withrefid)
 
 ## Fields
@@ -49,7 +49,7 @@ Accepted values for `value` are "code", "builder"
 ### fn withExemplar
 
 ```ts
-withExemplar(value)
+withExemplar(value=true)
 ```
 
 Execute an additional query to identify interesting raw samples relevant for the given expr
@@ -75,7 +75,7 @@ Accepted values for `value` are "time_series", "table", "heatmap"
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -85,7 +85,7 @@ the results from a hidden query may be used as the input to other queries (SSE e
 ### fn withInstant
 
 ```ts
-withInstant(value)
+withInstant(value=true)
 ```
 
 Returns only the latest value that Prometheus has scraped for the requested time series
@@ -118,7 +118,7 @@ TODO make this required and give it a default
 ### fn withRange
 
 ```ts
-withRange(value)
+withRange(value=true)
 ```
 
 Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/tempo.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/tempo.md
@@ -8,7 +8,7 @@ grafonnet.query.tempo
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withFilters(value)`](#fn-withfilters)
 * [`fn withFiltersMixin(value)`](#fn-withfiltersmixin)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLimit(value)`](#fn-withlimit)
 * [`fn withMaxDuration(value)`](#fn-withmaxduration)
 * [`fn withMinDuration(value)`](#fn-withminduration)
@@ -65,7 +65,7 @@ withFiltersMixin(value)
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/query/testData.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/query/testData.md
@@ -12,9 +12,9 @@ grafonnet.query.testData
 * [`fn withCsvWaveMixin(value)`](#fn-withcsvwavemixin)
 * [`fn withDatasource(value)`](#fn-withdatasource)
 * [`fn withErrorType(value)`](#fn-witherrortype)
-* [`fn withHide(value)`](#fn-withhide)
+* [`fn withHide(value=true)`](#fn-withhide)
 * [`fn withLabels(value)`](#fn-withlabels)
-* [`fn withLevelColumn(value)`](#fn-withlevelcolumn)
+* [`fn withLevelColumn(value=true)`](#fn-withlevelcolumn)
 * [`fn withLines(value)`](#fn-withlines)
 * [`fn withNodes(value)`](#fn-withnodes)
 * [`fn withNodesMixin(value)`](#fn-withnodesmixin)
@@ -54,8 +54,8 @@ grafonnet.query.testData
   * [`fn withConfigMixin(value)`](#fn-simwithconfigmixin)
   * [`fn withKey(value)`](#fn-simwithkey)
   * [`fn withKeyMixin(value)`](#fn-simwithkeymixin)
-  * [`fn withLast(value)`](#fn-simwithlast)
-  * [`fn withStream(value)`](#fn-simwithstream)
+  * [`fn withLast(value=true)`](#fn-simwithlast)
+  * [`fn withStream(value=true)`](#fn-simwithstream)
   * [`obj key`](#obj-simkey)
     * [`fn withTick(value)`](#fn-simkeywithtick)
     * [`fn withType(value)`](#fn-simkeywithtype)
@@ -149,7 +149,7 @@ Accepted values for `value` are "server_panic", "frontend_exception", "frontend_
 ### fn withHide
 
 ```ts
-withHide(value)
+withHide(value=true)
 ```
 
 true if query is disabled (ie should not be returned to the dashboard)
@@ -167,7 +167,7 @@ withLabels(value)
 ### fn withLevelColumn
 
 ```ts
-withLevelColumn(value)
+withLevelColumn(value=true)
 ```
 
 
@@ -474,7 +474,7 @@ withKeyMixin(value)
 #### fn sim.withLast
 
 ```ts
-withLast(value)
+withLast(value=true)
 ```
 
 
@@ -482,7 +482,7 @@ withLast(value)
 #### fn sim.withStream
 
 ```ts
-withStream(value)
+withStream(value=true)
 ```
 
 

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/serviceaccount.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/serviceaccount.md
@@ -9,7 +9,7 @@ grafonnet.serviceaccount
 * [`fn withAvatarUrl(value)`](#fn-withavatarurl)
 * [`fn withCreated(value)`](#fn-withcreated)
 * [`fn withId(value)`](#fn-withid)
-* [`fn withIsDisabled(value)`](#fn-withisdisabled)
+* [`fn withIsDisabled(value=true)`](#fn-withisdisabled)
 * [`fn withLogin(value)`](#fn-withlogin)
 * [`fn withName(value)`](#fn-withname)
 * [`fn withOrgId(value)`](#fn-withorgid)
@@ -65,7 +65,7 @@ ID is the unique identifier of the service account in the database.
 ### fn withIsDisabled
 
 ```ts
-withIsDisabled(value)
+withIsDisabled(value=true)
 ```
 
 IsDisabled indicates if the service account is disabled.

--- a/gen/grafonnet-v9.5.0/docs/grafonnet/util.md
+++ b/gen/grafonnet-v9.5.0/docs/grafonnet/util.md
@@ -7,7 +7,8 @@ Helper functions that work well with Grafonnet.
 * [`obj dashboard`](#obj-dashboard)
   * [`fn getOptionsForCustomQuery(query)`](#fn-dashboardgetoptionsforcustomquery)
 * [`obj grid`](#obj-grid)
-  * [`fn makeGrid(panels, panelWidth, panelHeight)`](#fn-gridmakegrid)
+  * [`fn makeGrid(panels, panelWidth, panelHeight, startY)`](#fn-gridmakegrid)
+  * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
 * [`obj string`](#obj-string)
@@ -40,7 +41,7 @@ compatible solution.
 #### fn grid.makeGrid
 
 ```ts
-makeGrid(panels, panelWidth, panelHeight)
+makeGrid(panels, panelWidth, panelHeight, startY)
 ```
 
 `makeGrid` returns an array of `panels` organized in a grid with equal `panelWidth`
@@ -50,6 +51,18 @@ then all panels below it will be folded into the row.
 This function will use the full grid of 24 columns, setting `panelWidth` to a value
 that can divide 24 into equal parts will fill up the page nicely. (1, 2, 3, 4, 6, 8, 12)
 Other value for `panelWidth` will leave a gap on the far right.
+
+Optional `startY` can be provided to place generated grid above or below existing panels.
+
+
+#### fn grid.wrapPanels
+
+```ts
+wrapPanels(panels, panelWidth, panelHeight, startY)
+```
+
+`wrapPanels` returns an array of `panels` organized in a grid, wrapping up to next 'row' if total width exceeds full grid of 24 columns.
+'panelHeight' and 'panelWidth' are used unless panels already have height and width defined.
 
 
 ### obj panel


### PR DESCRIPTION
CRDsonnet defaults to true for `withSomeBoolean()` as this is what the linguistics suggest
it does, this was not correctly reflected in the docs. This PR fixes the docs.