### PR TITLE
Add dependency check to Makefile

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,16 +1,10 @@
 # Development
+**Check Dependencies**: Use the `make check_dependencies` command to ensure that all necessary commands are available for generation.
 
-`make generate` uses `generate.jsonnet` to create Jsonnet libraries for each version in
-`gen/<version>/`, it also creates `gen/grafonnet-latest/` which refers to the newest
-version. These Jsonnet libraries depend on the JSON Schemas from Grok and `grafonnet-base/`.
+**Generate Jsonnet Libraries**: The `make generate` command uses `generate.jsonnet` to generate Jsonnet libraries for each version found in `gen/<version>/`. It also produces `gen/grafonnet-latest/` referring to the latest version. These libraries are dependent on the JSON schemas from Grok and the `grafonnet-base/`.
 
-`make libdocs` will generate the docs for every version in `gen/<version>/` and `make
-latestdocs` will generate the docs in `docs/` for the `gen/grafonnet-latest/`. `make docs`
-combines them.
+**Generate Library Documentation**: By running `make libdocs`, you can produce documentation for every version in `gen/<version>/`. To create documentation for the `gen/grafonnet-latest/` you can use the `make latestdocs` command, which outputs documentation to `docs/`. Use `make docs` to combine these generated documents.
 
-The `grafonnet-base/` library provides the logic to convert JSON Schemas to a runtime
-library and adds veneer on top. The veneer is a thin layer on top of the raw library to
-improve the user experience.
+**Grafonnet-base Library**: The `grafonnet-base/` library forms the basis for converting JSON schemas into a compiled library, additionally providing an overlay for improved user experience.
 
-In `examples/` there are few example dashboard configurations that serve as inspiration as
-well as an experimentation playground for library features.
+**Examples**: The `examples/` directory contains several example dashboard configurations, which can be used both for inspiration and as a testing ground for library features.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 LATEST := v10.0.0
 
+check_dependencies:
+	./scripts/dependancy_check.sh
+
 generate:
 	./scripts/generate.sh v10.0.0
 	./scripts/generate_latest.sh v10.0.0

--- a/scripts/dependancy_check.sh
+++ b/scripts/dependancy_check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+bash_version_check () {
+  MIN_BASH_VERSION=4
+
+  if [ "${BASH_VERSINFO:-0}" -ge ${MIN_BASH_VERSION} ]
+  then
+    echo "Warning bash version ${BASH_VERSINFO:-0} in use a minimum of bash version ${MIN_BASH_VERSION} is required"
+    exit 1
+  fi
+}
+
+check_dependencies () {
+  bash_version_check
+}
+
+check_dependencies

--- a/scripts/dependancy_check.sh
+++ b/scripts/dependancy_check.sh
@@ -1,19 +1,54 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
 
-bash_version_check () {
-  MIN_BASH_VERSION=4
+MIN_BASH_VERSION=4
+REQUIRED_COMMANDS=(
+  "mapfile"
+  "jb"
+  "jsonnet"
+  "jsonnetfmt"
+  "jrsonnet"
+  )
 
-  if [ "${BASH_VERSINFO:-0}" -ge ${MIN_BASH_VERSION} ]
-  then
-    echo "Warning bash version ${BASH_VERSINFO:-0} in use a minimum of bash version ${MIN_BASH_VERSION} is required"
+function check_command_availability () {
+  if ! command -v "${1}" >/dev/null 2>&1; then
+    echo "Warning: $1 could not be found."
     exit 1
+  else
+    echo "$1 found. Carry on."
   fi
 }
 
+bash_version_check () {
+  local bash_version="${BASH_VERSINFO[0]:-0}"
+
+  if ((bash_version < MIN_BASH_VERSION)); then
+    echo "Warning: bash version ${bash_version} found. A minimum bash version of ${MIN_BASH_VERSION} is required."
+    return 1
+  else
+    echo "Bash version ${bash_version} is sufficient. Carry on."
+  fi
+}
+
+required_commands_availability_check () {
+  for cmd in "${REQUIRED_COMMANDS[@]}"
+  do
+    if  command -v $cmd >/dev/null 2>&1
+    then
+      echo "$cmd found. Carry on."
+    else
+      echo "Warning: $cmd could not be found."
+      exit 1
+    fi
+  done
+}
+
 check_dependencies () {
-  bash_version_check
+  bash_version_check || exit 1
+
+  for cmd in "${REQUIRED_COMMANDS[@]}"; do
+    check_command_availability "$cmd" || exit 1
+  done
 }
 
 check_dependencies


### PR DESCRIPTION
A new Bash script `dependancy_check.sh` has been added to ensure that the minimum required Bash version is used and that required commands used by generate are available. This script is now called in the Makefile as part of the `check_dependencies` task. This aims to prevent errors due to incompatible Bash versions or missing commands.

After encountering some minor inconvenience debugging why then `generate.sh` script was failing, I added this script to ensure others don't waste any time.

Also, minor clean up of the Development readme.