### PR TITLE
Update `docsonnet` version to use release tags in dependencies

### DIFF
--- a/gen/grafonnet-v10.0.0/jsonnetfile.json
+++ b/gen/grafonnet-v10.0.0/jsonnetfile.json
@@ -7,7 +7,7 @@
           "subdir": "doc-util"
         }
       },
-      "version": "master"
+      "version": "v0.0.6"
     },
     {
       "source": {

--- a/generator/dependencies.libsonnet
+++ b/generator/dependencies.libsonnet
@@ -9,7 +9,7 @@
             subdir: 'doc-util',
           },
         },
-        version: 'master',
+        version: 'v0.0.6',
       },
       {
         source: {


### PR DESCRIPTION
Changed the library version for `docsonnet` from 'master' to a specific version 'v0.0.6' in dependencies.libsonnet to make use of the release version tags available for `docsonnet`. This ensures that we are using a particular stable version of the library, avoiding potential compatibility issues that can occur when using the master branch.