### PR TITLE
chore(generator): lock jsonnet library versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,24 @@
-.PHONY: generate localmkdocs test
+.PHONY: generate regenerate localmkdocs test
 
 LATEST := v10.0.0
 
-generate:
-	./scripts/generate.sh v10.0.0
-	./scripts/generate_latest.sh v10.0.0
+generate: gen/grafonnet-latest
+
+gen/grafonnet-latest:
+	./scripts/generate.sh ${LATEST} && \
+	./scripts/generate_latest.sh ${LATEST}
+
+regenerate: gen/grafonnet-v*
+
+# is latest, use `make generate` instead
+#gen/grafonnet-v10.0.0:
+#	./scripts/generate.sh v10.0.0
+
+gen/grafonnet-v9.5.0:
+	./scripts/generate.sh v9.5.0
+
+gen/grafonnet-v9.4.0:
+	./scripts/generate.sh v9.4.0
 
 localmkdocs:
 	python -m venv .mkdocs/.venv; \

--- a/generator/jsonnetfile.lock.json
+++ b/generator/jsonnetfile.lock.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/Duologic/jsonnet-libsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "bd08bf5f0ffc156bd755b916367bceb7fbe3de03",
+      "sum": "ZYc3KrgzQIciDlQ786i2iHeqEZqjnB8KlPiX6w8Mp38="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/crdsonnet/crdsonnet.git",
+          "subdir": "crdsonnet"
+        }
+      },
+      "version": "49e60058145609c36722251e4b9f65dd136fc7b2",
+      "sum": "jDeXDXH/CDBMJTRNs0bbYX5BVxCF/eRqkS/H73wa1qU="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/crdsonnet/validate-libsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "a78ca15fbfece3110c4807d1f059132ece01d97b",
+      "sum": "qYLH56MqvmgxE4YMNeTbuJ1XSsCpl1sumHN5x8IQv2I="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "4af7ba875dc578fc46a5e16d86ef3d0d4f4d2c15",
+      "sum": "O9XifwXLevw3HZxLJPDNmdk6VE2GH2xZfak1f9izF1s="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "0256a910ac71f0f842696d7bca0bf01ea77eb654",
+      "sum": "zBOpb1oTNvXdq9RF6yzTHill5r1YTJLBBoqyx4JYtAg="
+    }
+  ],
+  "legacyImports": false
+}

--- a/generator/jsonnetfile.lock.json
+++ b/generator/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "doc-util"
         }
       },
-      "version": "4af7ba875dc578fc46a5e16d86ef3d0d4f4d2c15",
-      "sum": "O9XifwXLevw3HZxLJPDNmdk6VE2GH2xZfak1f9izF1s="
+      "version": "fd8de9039b3c06da77d635a3a8289809a5bfb542",
+      "sum": "mFebrE9fhyAKW4zbnidcjVFupziN5LPA/Z7ii94uCzs="
     },
     {
       "source": {

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -16,8 +16,10 @@ trap finish EXIT
 cd "${TEMP}"
 
 jb init
-jb install "github.com/grafana/grok/jsonnet/${VERSION}@main"
 cp -r "${REPO_DIR}/generator" generator
+cp -r "${REPO_DIR}/generator/jsonnetfile.lock.json" .
+jb install
+jb install "github.com/grafana/grok/jsonnet/${VERSION}@main"
 jb install ./generator
 
 OUT_DIR="${REPO_DIR}/gen"

--- a/scripts/generate_latest.sh
+++ b/scripts/generate_latest.sh
@@ -16,13 +16,15 @@ trap finish EXIT
 cd "${TEMP}"
 
 jb init
-jb install "github.com/grafana/grok/jsonnet/${VERSION}@main"
 cp -r "${REPO_DIR}/generator" generator
+cp -r "${REPO_DIR}/generator/jsonnetfile.lock.json" .
+jb install
+jb install "github.com/grafana/grok/jsonnet/${VERSION}@main"
 jb install ./generator
 
 OUT_DIR="${REPO_DIR}/gen"
-LATEST_DIR="${OUT_DIR}/grafonnet-${VERSION}"
 GEN_DIR="${OUT_DIR}/grafonnet-latest"
+LATEST_DIR="${OUT_DIR}/grafonnet-${VERSION}"
 
 rm -rf "${GEN_DIR}"
 mkdir -p "${GEN_DIR}"


### PR DESCRIPTION
A bit of housekeeping:
- Lock versions to ensure reproducible builds 
  (replaces #125)
- Add make targets for all current versions