### PR TITLE
feat: add alerting

### DIFF
--- a/custom/alerting/contactPoint.libsonnet
+++ b/custom/alerting/contactPoint.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#'+:: {
+    help+:
+      |||
+
+
+        **NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+      |||,
+  },
+}

--- a/custom/alerting/muteTiming.libsonnet
+++ b/custom/alerting/muteTiming.libsonnet
@@ -1,0 +1,8 @@
+{
+  '#withTimeIntervals': { ignore: true },
+  '#withIntervals': super['#withTimeIntervals'],
+  withIntervals: super.withTimeIntervals,
+  '#withTimeIntervalsMixin': { ignore: true },
+  '#withIntervalsMixin': super['#withTimeIntervalsMixin'],
+  withIntervalsMixin: super.withTimeIntervalsMixin,
+}

--- a/custom/alerting/notificationPolicy.libsonnet
+++ b/custom/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,12 @@
+{
+  '#withReceiver': { ignore: true },
+  '#withContactPoint': super['#withReceiver'],
+  withContactPoint: super.withReceiver,
+
+  '#withRoutes': { ignore: true },
+  '#withPolicy': super['#withRoutes'],
+  withPolicy: super.withRoutes,
+  '#withRoutesMixin': { ignore: true },
+  '#withPolicyMixin': super['#withRoutesMixin'],
+  withPolicyMixin: super.withRoutesMixin,
+}

--- a/custom/alerting/ruleGroup.libsonnet
+++ b/custom/alerting/ruleGroup.libsonnet
@@ -1,0 +1,13 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#withTitle': { ignore: true },
+  '#withName': super['#withTitle'],
+  withName: super.withTitle,
+  rule+: {
+    '#':: d.package.newSub('rule', ''),
+    '#withTitle': { ignore: true },
+    '#withName': super['#withTitle'],
+    withName: super.withTitle,
+  },
+}

--- a/docs/API/alerting/contactPoint.md
+++ b/docs/API/alerting/contactPoint.md
@@ -1,0 +1,100 @@
+# contactPoint
+
+grafonnet.alerting.contactPoint
+
+**NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+
+
+## Index
+
+* [`fn withDisableResolveMessage(value=true)`](#fn-withdisableresolvemessage)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withProvenance(value)`](#fn-withprovenance)
+* [`fn withSettings(value)`](#fn-withsettings)
+* [`fn withSettingsMixin(value)`](#fn-withsettingsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withUid(value)`](#fn-withuid)
+
+## Fields
+
+### fn withDisableResolveMessage
+
+```jsonnet
+withDisableResolveMessage(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Name is used as grouping key in the UI. Contact points with the
+same name will be grouped in the UI.
+### fn withProvenance
+
+```jsonnet
+withProvenance(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSettings
+
+```jsonnet
+withSettings(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withSettingsMixin
+
+```jsonnet
+withSettingsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"alertmanager"`, `" dingding"`, `" discord"`, `" email"`, `" googlechat"`, `" kafka"`, `" line"`, `" opsgenie"`, `" pagerduty"`, `" pushover"`, `" sensugo"`, `" slack"`, `" teams"`, `" telegram"`, `" threema"`, `" victorops"`, `" webhook"`, `" wecom"`
+
+
+### fn withUid
+
+```jsonnet
+withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+UID is the unique identifier of the contact point. The UID can be
+set by the user.

--- a/docs/API/alerting/index.md
+++ b/docs/API/alerting/index.md
@@ -1,0 +1,11 @@
+# alerting
+
+grafonnet.alerting
+
+## Subpackages
+
+* [contactPoint](contactPoint.md)
+* [messageTemplate](messageTemplate.md)
+* [muteTiming](muteTiming/index.md)
+* [notificationPolicy](notificationPolicy/index.md)
+* [ruleGroup](ruleGroup/index.md)

--- a/docs/API/alerting/messageTemplate.md
+++ b/docs/API/alerting/messageTemplate.md
@@ -1,0 +1,32 @@
+# messageTemplate
+
+grafonnet.alerting.messageTemplate
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withTemplate(value)`](#fn-withtemplate)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTemplate
+
+```jsonnet
+withTemplate(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/docs/API/alerting/muteTiming/index.md
+++ b/docs/API/alerting/muteTiming/index.md
@@ -1,0 +1,48 @@
+# muteTiming
+
+grafonnet.alerting.muteTiming
+
+## Subpackages
+
+* [interval](interval/index.md)
+
+## Index
+
+* [`fn withIntervals(value)`](#fn-withintervals)
+* [`fn withIntervalsMixin(value)`](#fn-withintervalsmixin)
+* [`fn withName(value)`](#fn-withname)
+
+## Fields
+
+### fn withIntervals
+
+```jsonnet
+withIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withIntervalsMixin
+
+```jsonnet
+withIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/docs/API/alerting/muteTiming/interval/index.md
+++ b/docs/API/alerting/muteTiming/interval/index.md
@@ -1,0 +1,144 @@
+# interval
+
+
+
+## Subpackages
+
+* [times](times.md)
+
+## Index
+
+* [`fn withDaysOfMonth(value)`](#fn-withdaysofmonth)
+* [`fn withDaysOfMonthMixin(value)`](#fn-withdaysofmonthmixin)
+* [`fn withLocation(value)`](#fn-withlocation)
+* [`fn withMonths(value)`](#fn-withmonths)
+* [`fn withMonthsMixin(value)`](#fn-withmonthsmixin)
+* [`fn withTimes(value)`](#fn-withtimes)
+* [`fn withTimesMixin(value)`](#fn-withtimesmixin)
+* [`fn withWeekdays(value)`](#fn-withweekdays)
+* [`fn withWeekdaysMixin(value)`](#fn-withweekdaysmixin)
+* [`fn withYears(value)`](#fn-withyears)
+* [`fn withYearsMixin(value)`](#fn-withyearsmixin)
+
+## Fields
+
+### fn withDaysOfMonth
+
+```jsonnet
+withDaysOfMonth(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDaysOfMonthMixin
+
+```jsonnet
+withDaysOfMonthMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withLocation
+
+```jsonnet
+withLocation(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMonths
+
+```jsonnet
+withMonths(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMonthsMixin
+
+```jsonnet
+withMonthsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimes
+
+```jsonnet
+withTimes(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimesMixin
+
+```jsonnet
+withTimesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdays
+
+```jsonnet
+withWeekdays(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdaysMixin
+
+```jsonnet
+withWeekdaysMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYears
+
+```jsonnet
+withYears(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYearsMixin
+
+```jsonnet
+withYearsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/docs/API/alerting/muteTiming/interval/times.md
+++ b/docs/API/alerting/muteTiming/interval/times.md
@@ -1,0 +1,32 @@
+# times
+
+
+
+## Index
+
+* [`fn withFrom(value)`](#fn-withfrom)
+* [`fn withTo(value)`](#fn-withto)
+
+## Fields
+
+### fn withFrom
+
+```jsonnet
+withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTo
+
+```jsonnet
+withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/docs/API/alerting/notificationPolicy/index.md
+++ b/docs/API/alerting/notificationPolicy/index.md
@@ -1,0 +1,173 @@
+# notificationPolicy
+
+grafonnet.alerting.notificationPolicy
+
+## Subpackages
+
+* [matcher](matcher.md)
+
+## Index
+
+* [`fn withContactPoint(value)`](#fn-withcontactpoint)
+* [`fn withContinue(value=true)`](#fn-withcontinue)
+* [`fn withGroupBy(value)`](#fn-withgroupby)
+* [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
+* [`fn withGroupInterval(value)`](#fn-withgroupinterval)
+* [`fn withGroupWait(value)`](#fn-withgroupwait)
+* [`fn withMatchers(value)`](#fn-withmatchers)
+* [`fn withMatchersMixin(value)`](#fn-withmatchersmixin)
+* [`fn withMuteTimeIntervals(value)`](#fn-withmutetimeintervals)
+* [`fn withMuteTimeIntervalsMixin(value)`](#fn-withmutetimeintervalsmixin)
+* [`fn withPolicy(value)`](#fn-withpolicy)
+* [`fn withPolicyMixin(value)`](#fn-withpolicymixin)
+* [`fn withRepeatInterval(value)`](#fn-withrepeatinterval)
+
+## Fields
+
+### fn withContactPoint
+
+```jsonnet
+withContactPoint(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withContinue
+
+```jsonnet
+withContinue(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withGroupBy
+
+```jsonnet
+withGroupBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupByMixin
+
+```jsonnet
+withGroupByMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupInterval
+
+```jsonnet
+withGroupInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withGroupWait
+
+```jsonnet
+withGroupWait(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMatchers
+
+```jsonnet
+withMatchers(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMatchersMixin
+
+```jsonnet
+withMatchersMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMuteTimeIntervals
+
+```jsonnet
+withMuteTimeIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMuteTimeIntervalsMixin
+
+```jsonnet
+withMuteTimeIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicy
+
+```jsonnet
+withPolicy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicyMixin
+
+```jsonnet
+withPolicyMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRepeatInterval
+
+```jsonnet
+withRepeatInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/docs/API/alerting/notificationPolicy/matcher.md
+++ b/docs/API/alerting/notificationPolicy/matcher.md
@@ -1,0 +1,45 @@
+# matcher
+
+
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withValue(value)`](#fn-withvalue)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"="`, `"!="`, `"=~"`, `"!~"`
+
+MatchType is an enum for label matching types.
+### fn withValue
+
+```jsonnet
+withValue(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/docs/API/alerting/ruleGroup/index.md
+++ b/docs/API/alerting/ruleGroup/index.md
@@ -1,0 +1,72 @@
+# ruleGroup
+
+grafonnet.alerting.ruleGroup
+
+## Subpackages
+
+* [rule](rule/index.md)
+
+## Index
+
+* [`fn withFolderUid(value)`](#fn-withfolderuid)
+* [`fn withInterval(value)`](#fn-withinterval)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRules(value)`](#fn-withrules)
+* [`fn withRulesMixin(value)`](#fn-withrulesmixin)
+
+## Fields
+
+### fn withFolderUid
+
+```jsonnet
+withFolderUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withInterval
+
+```jsonnet
+withInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withRules
+
+```jsonnet
+withRules(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRulesMixin
+
+```jsonnet
+withRulesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/docs/API/alerting/ruleGroup/rule/data.md
+++ b/docs/API/alerting/ruleGroup/rule/data.md
@@ -1,0 +1,128 @@
+# data
+
+
+
+## Index
+
+* [`fn withDatasourceUid(value)`](#fn-withdatasourceuid)
+* [`fn withModel(value)`](#fn-withmodel)
+* [`fn withModelMixin(value)`](#fn-withmodelmixin)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withRelativeTimeRange(value)`](#fn-withrelativetimerange)
+* [`fn withRelativeTimeRangeMixin(value)`](#fn-withrelativetimerangemixin)
+* [`obj relativeTimeRange`](#obj-relativetimerange)
+  * [`fn withFrom(value)`](#fn-relativetimerangewithfrom)
+  * [`fn withTo(value)`](#fn-relativetimerangewithto)
+
+## Fields
+
+### fn withDatasourceUid
+
+```jsonnet
+withDatasourceUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation.
+### fn withModel
+
+```jsonnet
+withModel(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withModelMixin
+
+```jsonnet
+withModelMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+RefID is the unique identifier of the query, set by the frontend call.
+### fn withRelativeTimeRange
+
+```jsonnet
+withRelativeTimeRange(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### fn withRelativeTimeRangeMixin
+
+```jsonnet
+withRelativeTimeRangeMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### obj relativeTimeRange
+
+
+#### fn relativeTimeRange.withFrom
+
+```jsonnet
+relativeTimeRange.withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+#### fn relativeTimeRange.withTo
+
+```jsonnet
+relativeTimeRange.withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.

--- a/docs/API/alerting/ruleGroup/rule/index.md
+++ b/docs/API/alerting/ruleGroup/rule/index.md
@@ -1,0 +1,161 @@
+# rule
+
+
+
+## Subpackages
+
+* [data](data.md)
+
+## Index
+
+* [`fn withAnnotations(value)`](#fn-withannotations)
+* [`fn withAnnotationsMixin(value)`](#fn-withannotationsmixin)
+* [`fn withCondition(value)`](#fn-withcondition)
+* [`fn withData(value)`](#fn-withdata)
+* [`fn withDataMixin(value)`](#fn-withdatamixin)
+* [`fn withExecErrState(value)`](#fn-withexecerrstate)
+* [`fn withFor(value)`](#fn-withfor)
+* [`fn withIsPaused(value=true)`](#fn-withispaused)
+* [`fn withLabels(value)`](#fn-withlabels)
+* [`fn withLabelsMixin(value)`](#fn-withlabelsmixin)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withNoDataState(value)`](#fn-withnodatastate)
+
+## Fields
+
+### fn withAnnotations
+
+```jsonnet
+withAnnotations(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withAnnotationsMixin
+
+```jsonnet
+withAnnotationsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withCondition
+
+```jsonnet
+withCondition(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withData
+
+```jsonnet
+withData(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDataMixin
+
+```jsonnet
+withDataMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withExecErrState
+
+```jsonnet
+withExecErrState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"OK"`, `"Alerting"`, `"Error"`
+
+
+### fn withFor
+
+```jsonnet
+withFor(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+### fn withIsPaused
+
+```jsonnet
+withIsPaused(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withLabels
+
+```jsonnet
+withLabels(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withLabelsMixin
+
+```jsonnet
+withLabelsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withNoDataState
+
+```jsonnet
+withNoDataState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"NoData"`, `"OK"`
+

--- a/docs/API/index.md
+++ b/docs/API/index.md
@@ -5,6 +5,7 @@
 ## Subpackages
 
 * [accesspolicy](accesspolicy/index.md)
+* [alerting](alerting/index.md)
 * [dashboard](dashboard/index.md)
 * [folder](folder.md)
 * [librarypanel](librarypanel.md)

--- a/gen/grafonnet-v10.0.0/alerting.libsonnet
+++ b/gen/grafonnet-v10.0.0/alerting.libsonnet
@@ -1,0 +1,9 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting', name: 'alerting' },
+  contactPoint: import 'clean/alerting/contactPoint.libsonnet',
+  notificationPolicy: import 'clean/alerting/notificationPolicy.libsonnet',
+  muteTiming: import 'clean/alerting/muteTiming.libsonnet',
+  ruleGroup: import 'clean/alerting/ruleGroup.libsonnet',
+  messageTemplate: import 'clean/alerting/messageTemplate.libsonnet',
+}

--- a/gen/grafonnet-v10.0.0/clean/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.0.0/clean/alerting/contactPoint.libsonnet
@@ -1,0 +1,19 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}
++ (import '../../custom/alerting/contactPoint.libsonnet')

--- a/gen/grafonnet-v10.0.0/clean/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v10.0.0/clean/alerting/messageTemplate.libsonnet
@@ -1,0 +1,8 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v10.0.0/clean/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.0.0/clean/alerting/muteTiming.libsonnet
@@ -1,0 +1,69 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  interval+:
+    {
+      '#': { help: '', name: 'interval' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withFrom(value): { from: value },
+          '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withTo(value): { to: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}
++ (import '../../custom/alerting/muteTiming.libsonnet')

--- a/gen/grafonnet-v10.0.0/clean/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.0.0/clean/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,57 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+  matcher+:
+    {
+      '#': { help: '', name: 'matcher' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+}
++ (import '../../custom/alerting/notificationPolicy.libsonnet')

--- a/gen/grafonnet-v10.0.0/clean/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.0.0/clean/alerting/ruleGroup.libsonnet
@@ -1,0 +1,75 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+  rule+:
+    {
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['OK', 'Alerting', 'Error'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+    },
+}
++ (import '../../custom/alerting/ruleGroup.libsonnet')

--- a/gen/grafonnet-v10.0.0/custom/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/alerting/contactPoint.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#'+:: {
+    help+:
+      |||
+
+
+        **NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+      |||,
+  },
+}

--- a/gen/grafonnet-v10.0.0/custom/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/alerting/muteTiming.libsonnet
@@ -1,0 +1,8 @@
+{
+  '#withTimeIntervals': { ignore: true },
+  '#withIntervals': super['#withTimeIntervals'],
+  withIntervals: super.withTimeIntervals,
+  '#withTimeIntervalsMixin': { ignore: true },
+  '#withIntervalsMixin': super['#withTimeIntervalsMixin'],
+  withIntervalsMixin: super.withTimeIntervalsMixin,
+}

--- a/gen/grafonnet-v10.0.0/custom/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,12 @@
+{
+  '#withReceiver': { ignore: true },
+  '#withContactPoint': super['#withReceiver'],
+  withContactPoint: super.withReceiver,
+
+  '#withRoutes': { ignore: true },
+  '#withPolicy': super['#withRoutes'],
+  withPolicy: super.withRoutes,
+  '#withRoutesMixin': { ignore: true },
+  '#withPolicyMixin': super['#withRoutesMixin'],
+  withPolicyMixin: super.withRoutesMixin,
+}

--- a/gen/grafonnet-v10.0.0/custom/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/alerting/ruleGroup.libsonnet
@@ -1,0 +1,13 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#withTitle': { ignore: true },
+  '#withName': super['#withTitle'],
+  withName: super.withTitle,
+  rule+: {
+    '#':: d.package.newSub('rule', ''),
+    '#withTitle': { ignore: true },
+    '#withName': super['#withTitle'],
+    withName: super.withTitle,
+  },
+}

--- a/gen/grafonnet-v10.0.0/docs/README.md
+++ b/gen/grafonnet-v10.0.0/docs/README.md
@@ -16,6 +16,7 @@ local grafonnet = import "github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/mai
 
 ## Subpackages
 
+* [alerting](alerting/index.md)
 * [dashboard](dashboard/index.md)
 * [librarypanel](librarypanel.md)
 * [panel](panel/index.md)

--- a/gen/grafonnet-v10.0.0/docs/alerting/contactPoint.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/contactPoint.md
@@ -1,0 +1,100 @@
+# contactPoint
+
+grafonnet.alerting.contactPoint
+
+**NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+
+
+## Index
+
+* [`fn withDisableResolveMessage(value=true)`](#fn-withdisableresolvemessage)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withProvenance(value)`](#fn-withprovenance)
+* [`fn withSettings(value)`](#fn-withsettings)
+* [`fn withSettingsMixin(value)`](#fn-withsettingsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withUid(value)`](#fn-withuid)
+
+## Fields
+
+### fn withDisableResolveMessage
+
+```jsonnet
+withDisableResolveMessage(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Name is used as grouping key in the UI. Contact points with the
+same name will be grouped in the UI.
+### fn withProvenance
+
+```jsonnet
+withProvenance(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSettings
+
+```jsonnet
+withSettings(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withSettingsMixin
+
+```jsonnet
+withSettingsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"alertmanager"`, `" dingding"`, `" discord"`, `" email"`, `" googlechat"`, `" kafka"`, `" line"`, `" opsgenie"`, `" pagerduty"`, `" pushover"`, `" sensugo"`, `" slack"`, `" teams"`, `" telegram"`, `" threema"`, `" victorops"`, `" webhook"`, `" wecom"`
+
+
+### fn withUid
+
+```jsonnet
+withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+UID is the unique identifier of the contact point. The UID can be
+set by the user.

--- a/gen/grafonnet-v10.0.0/docs/alerting/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/index.md
@@ -1,0 +1,11 @@
+# alerting
+
+grafonnet.alerting
+
+## Subpackages
+
+* [contactPoint](contactPoint.md)
+* [messageTemplate](messageTemplate.md)
+* [muteTiming](muteTiming/index.md)
+* [notificationPolicy](notificationPolicy/index.md)
+* [ruleGroup](ruleGroup/index.md)

--- a/gen/grafonnet-v10.0.0/docs/alerting/messageTemplate.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/messageTemplate.md
@@ -1,0 +1,32 @@
+# messageTemplate
+
+grafonnet.alerting.messageTemplate
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withTemplate(value)`](#fn-withtemplate)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTemplate
+
+```jsonnet
+withTemplate(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/index.md
@@ -1,0 +1,48 @@
+# muteTiming
+
+grafonnet.alerting.muteTiming
+
+## Subpackages
+
+* [interval](interval/index.md)
+
+## Index
+
+* [`fn withIntervals(value)`](#fn-withintervals)
+* [`fn withIntervalsMixin(value)`](#fn-withintervalsmixin)
+* [`fn withName(value)`](#fn-withname)
+
+## Fields
+
+### fn withIntervals
+
+```jsonnet
+withIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withIntervalsMixin
+
+```jsonnet
+withIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/interval/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/interval/index.md
@@ -1,0 +1,144 @@
+# interval
+
+
+
+## Subpackages
+
+* [times](times.md)
+
+## Index
+
+* [`fn withDaysOfMonth(value)`](#fn-withdaysofmonth)
+* [`fn withDaysOfMonthMixin(value)`](#fn-withdaysofmonthmixin)
+* [`fn withLocation(value)`](#fn-withlocation)
+* [`fn withMonths(value)`](#fn-withmonths)
+* [`fn withMonthsMixin(value)`](#fn-withmonthsmixin)
+* [`fn withTimes(value)`](#fn-withtimes)
+* [`fn withTimesMixin(value)`](#fn-withtimesmixin)
+* [`fn withWeekdays(value)`](#fn-withweekdays)
+* [`fn withWeekdaysMixin(value)`](#fn-withweekdaysmixin)
+* [`fn withYears(value)`](#fn-withyears)
+* [`fn withYearsMixin(value)`](#fn-withyearsmixin)
+
+## Fields
+
+### fn withDaysOfMonth
+
+```jsonnet
+withDaysOfMonth(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDaysOfMonthMixin
+
+```jsonnet
+withDaysOfMonthMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withLocation
+
+```jsonnet
+withLocation(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMonths
+
+```jsonnet
+withMonths(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMonthsMixin
+
+```jsonnet
+withMonthsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimes
+
+```jsonnet
+withTimes(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimesMixin
+
+```jsonnet
+withTimesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdays
+
+```jsonnet
+withWeekdays(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdaysMixin
+
+```jsonnet
+withWeekdaysMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYears
+
+```jsonnet
+withYears(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYearsMixin
+
+```jsonnet
+withYearsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/interval/times.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/muteTiming/interval/times.md
@@ -1,0 +1,32 @@
+# times
+
+
+
+## Index
+
+* [`fn withFrom(value)`](#fn-withfrom)
+* [`fn withTo(value)`](#fn-withto)
+
+## Fields
+
+### fn withFrom
+
+```jsonnet
+withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTo
+
+```jsonnet
+withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/notificationPolicy/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/notificationPolicy/index.md
@@ -1,0 +1,173 @@
+# notificationPolicy
+
+grafonnet.alerting.notificationPolicy
+
+## Subpackages
+
+* [matcher](matcher.md)
+
+## Index
+
+* [`fn withContactPoint(value)`](#fn-withcontactpoint)
+* [`fn withContinue(value=true)`](#fn-withcontinue)
+* [`fn withGroupBy(value)`](#fn-withgroupby)
+* [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
+* [`fn withGroupInterval(value)`](#fn-withgroupinterval)
+* [`fn withGroupWait(value)`](#fn-withgroupwait)
+* [`fn withMatchers(value)`](#fn-withmatchers)
+* [`fn withMatchersMixin(value)`](#fn-withmatchersmixin)
+* [`fn withMuteTimeIntervals(value)`](#fn-withmutetimeintervals)
+* [`fn withMuteTimeIntervalsMixin(value)`](#fn-withmutetimeintervalsmixin)
+* [`fn withPolicy(value)`](#fn-withpolicy)
+* [`fn withPolicyMixin(value)`](#fn-withpolicymixin)
+* [`fn withRepeatInterval(value)`](#fn-withrepeatinterval)
+
+## Fields
+
+### fn withContactPoint
+
+```jsonnet
+withContactPoint(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withContinue
+
+```jsonnet
+withContinue(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withGroupBy
+
+```jsonnet
+withGroupBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupByMixin
+
+```jsonnet
+withGroupByMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupInterval
+
+```jsonnet
+withGroupInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withGroupWait
+
+```jsonnet
+withGroupWait(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMatchers
+
+```jsonnet
+withMatchers(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMatchersMixin
+
+```jsonnet
+withMatchersMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMuteTimeIntervals
+
+```jsonnet
+withMuteTimeIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMuteTimeIntervalsMixin
+
+```jsonnet
+withMuteTimeIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicy
+
+```jsonnet
+withPolicy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicyMixin
+
+```jsonnet
+withPolicyMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRepeatInterval
+
+```jsonnet
+withRepeatInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/notificationPolicy/matcher.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/notificationPolicy/matcher.md
@@ -1,0 +1,45 @@
+# matcher
+
+
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withValue(value)`](#fn-withvalue)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"="`, `"!="`, `"=~"`, `"!~"`
+
+MatchType is an enum for label matching types.
+### fn withValue
+
+```jsonnet
+withValue(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/index.md
@@ -1,0 +1,72 @@
+# ruleGroup
+
+grafonnet.alerting.ruleGroup
+
+## Subpackages
+
+* [rule](rule/index.md)
+
+## Index
+
+* [`fn withFolderUid(value)`](#fn-withfolderuid)
+* [`fn withInterval(value)`](#fn-withinterval)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRules(value)`](#fn-withrules)
+* [`fn withRulesMixin(value)`](#fn-withrulesmixin)
+
+## Fields
+
+### fn withFolderUid
+
+```jsonnet
+withFolderUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withInterval
+
+```jsonnet
+withInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withRules
+
+```jsonnet
+withRules(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRulesMixin
+
+```jsonnet
+withRulesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/rule/data.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/rule/data.md
@@ -1,0 +1,128 @@
+# data
+
+
+
+## Index
+
+* [`fn withDatasourceUid(value)`](#fn-withdatasourceuid)
+* [`fn withModel(value)`](#fn-withmodel)
+* [`fn withModelMixin(value)`](#fn-withmodelmixin)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withRelativeTimeRange(value)`](#fn-withrelativetimerange)
+* [`fn withRelativeTimeRangeMixin(value)`](#fn-withrelativetimerangemixin)
+* [`obj relativeTimeRange`](#obj-relativetimerange)
+  * [`fn withFrom(value)`](#fn-relativetimerangewithfrom)
+  * [`fn withTo(value)`](#fn-relativetimerangewithto)
+
+## Fields
+
+### fn withDatasourceUid
+
+```jsonnet
+withDatasourceUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation.
+### fn withModel
+
+```jsonnet
+withModel(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withModelMixin
+
+```jsonnet
+withModelMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+RefID is the unique identifier of the query, set by the frontend call.
+### fn withRelativeTimeRange
+
+```jsonnet
+withRelativeTimeRange(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### fn withRelativeTimeRangeMixin
+
+```jsonnet
+withRelativeTimeRangeMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### obj relativeTimeRange
+
+
+#### fn relativeTimeRange.withFrom
+
+```jsonnet
+relativeTimeRange.withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+#### fn relativeTimeRange.withTo
+
+```jsonnet
+relativeTimeRange.withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.

--- a/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/rule/index.md
+++ b/gen/grafonnet-v10.0.0/docs/alerting/ruleGroup/rule/index.md
@@ -1,0 +1,161 @@
+# rule
+
+
+
+## Subpackages
+
+* [data](data.md)
+
+## Index
+
+* [`fn withAnnotations(value)`](#fn-withannotations)
+* [`fn withAnnotationsMixin(value)`](#fn-withannotationsmixin)
+* [`fn withCondition(value)`](#fn-withcondition)
+* [`fn withData(value)`](#fn-withdata)
+* [`fn withDataMixin(value)`](#fn-withdatamixin)
+* [`fn withExecErrState(value)`](#fn-withexecerrstate)
+* [`fn withFor(value)`](#fn-withfor)
+* [`fn withIsPaused(value=true)`](#fn-withispaused)
+* [`fn withLabels(value)`](#fn-withlabels)
+* [`fn withLabelsMixin(value)`](#fn-withlabelsmixin)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withNoDataState(value)`](#fn-withnodatastate)
+
+## Fields
+
+### fn withAnnotations
+
+```jsonnet
+withAnnotations(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withAnnotationsMixin
+
+```jsonnet
+withAnnotationsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withCondition
+
+```jsonnet
+withCondition(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withData
+
+```jsonnet
+withData(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDataMixin
+
+```jsonnet
+withDataMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withExecErrState
+
+```jsonnet
+withExecErrState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"OK"`, `"Alerting"`, `"Error"`
+
+
+### fn withFor
+
+```jsonnet
+withFor(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+### fn withIsPaused
+
+```jsonnet
+withIsPaused(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withLabels
+
+```jsonnet
+withLabels(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withLabelsMixin
+
+```jsonnet
+withLabelsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withNoDataState
+
+```jsonnet
+withNoDataState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"NoData"`, `"OK"`
+

--- a/gen/grafonnet-v10.0.0/main.libsonnet
+++ b/gen/grafonnet-v10.0.0/main.libsonnet
@@ -20,4 +20,5 @@
   panel: import 'panel.libsonnet',
   query: import 'query.libsonnet',
   util: import 'custom/util/main.libsonnet',
+  alerting: import 'alerting.libsonnet',
 }

--- a/gen/grafonnet-v10.0.0/raw/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.0.0/raw/alerting/contactPoint.libsonnet
@@ -1,0 +1,18 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}

--- a/gen/grafonnet-v10.0.0/raw/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v10.0.0/raw/alerting/messageTemplate.libsonnet
@@ -1,0 +1,10 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v10.0.0/raw/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.0.0/raw/alerting/muteTiming.libsonnet
@@ -1,0 +1,68 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  time_intervals+:
+    {
+      '#': { help: '', name: 'time_intervals' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withFrom(value): { from: value },
+          '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withTo(value): { to: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}

--- a/gen/grafonnet-v10.0.0/raw/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.0.0/raw/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,84 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withMatch': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatch(value): { match: value },
+  '#withMatchMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatchMixin(value): { match+: value },
+  '#withMatchRe': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchRe(value): { match_re: value },
+  '#withMatchReMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchReMixin(value): { match_re+: value },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  matchers+:
+    {
+      '#': { help: '', name: 'matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withObjectMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchers(value): { object_matchers: (if std.isArray(value)
+                                                 then value
+                                                 else [value]) },
+  '#withObjectMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchersMixin(value): { object_matchers+: (if std.isArray(value)
+                                                       then value
+                                                       else [value]) },
+  object_matchers+:
+    {
+      '#': { help: '', name: 'object_matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+}

--- a/gen/grafonnet-v10.0.0/raw/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.0.0/raw/alerting/ruleGroup.libsonnet
@@ -1,0 +1,89 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  rules+:
+    {
+      '#': { help: '', name: 'rules' },
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['OK', 'Alerting', 'Error'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFolderUID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withFolderUID(value): { folderUID: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withId(value): { id: value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withOrgID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withOrgID(value): { orgID: value },
+      '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withProvenance(value): { provenance: value },
+      '#withRuleGroup': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withRuleGroup(value): { ruleGroup: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUid(value): { uid: value },
+      '#withUpdated': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUpdated(value): { updated: value },
+    },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+}

--- a/gen/grafonnet-v10.1.0/alerting.libsonnet
+++ b/gen/grafonnet-v10.1.0/alerting.libsonnet
@@ -1,0 +1,9 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting', name: 'alerting' },
+  contactPoint: import 'clean/alerting/contactPoint.libsonnet',
+  notificationPolicy: import 'clean/alerting/notificationPolicy.libsonnet',
+  muteTiming: import 'clean/alerting/muteTiming.libsonnet',
+  ruleGroup: import 'clean/alerting/ruleGroup.libsonnet',
+  messageTemplate: import 'clean/alerting/messageTemplate.libsonnet',
+}

--- a/gen/grafonnet-v10.1.0/clean/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.1.0/clean/alerting/contactPoint.libsonnet
@@ -1,0 +1,19 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}
++ (import '../../custom/alerting/contactPoint.libsonnet')

--- a/gen/grafonnet-v10.1.0/clean/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v10.1.0/clean/alerting/messageTemplate.libsonnet
@@ -1,0 +1,8 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v10.1.0/clean/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.1.0/clean/alerting/muteTiming.libsonnet
@@ -1,0 +1,69 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  interval+:
+    {
+      '#': { help: '', name: 'interval' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withFrom(value): { from: value },
+          '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withTo(value): { to: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}
++ (import '../../custom/alerting/muteTiming.libsonnet')

--- a/gen/grafonnet-v10.1.0/clean/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.1.0/clean/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,57 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+  matcher+:
+    {
+      '#': { help: '', name: 'matcher' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+}
++ (import '../../custom/alerting/notificationPolicy.libsonnet')

--- a/gen/grafonnet-v10.1.0/clean/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.1.0/clean/alerting/ruleGroup.libsonnet
@@ -1,0 +1,75 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+  rule+:
+    {
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['OK', 'Alerting', 'Error'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+    },
+}
++ (import '../../custom/alerting/ruleGroup.libsonnet')

--- a/gen/grafonnet-v10.1.0/custom/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/alerting/contactPoint.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#'+:: {
+    help+:
+      |||
+
+
+        **NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+      |||,
+  },
+}

--- a/gen/grafonnet-v10.1.0/custom/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/alerting/muteTiming.libsonnet
@@ -1,0 +1,8 @@
+{
+  '#withTimeIntervals': { ignore: true },
+  '#withIntervals': super['#withTimeIntervals'],
+  withIntervals: super.withTimeIntervals,
+  '#withTimeIntervalsMixin': { ignore: true },
+  '#withIntervalsMixin': super['#withTimeIntervalsMixin'],
+  withIntervalsMixin: super.withTimeIntervalsMixin,
+}

--- a/gen/grafonnet-v10.1.0/custom/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,12 @@
+{
+  '#withReceiver': { ignore: true },
+  '#withContactPoint': super['#withReceiver'],
+  withContactPoint: super.withReceiver,
+
+  '#withRoutes': { ignore: true },
+  '#withPolicy': super['#withRoutes'],
+  withPolicy: super.withRoutes,
+  '#withRoutesMixin': { ignore: true },
+  '#withPolicyMixin': super['#withRoutesMixin'],
+  withPolicyMixin: super.withRoutesMixin,
+}

--- a/gen/grafonnet-v10.1.0/custom/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/alerting/ruleGroup.libsonnet
@@ -1,0 +1,13 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#withTitle': { ignore: true },
+  '#withName': super['#withTitle'],
+  withName: super.withTitle,
+  rule+: {
+    '#':: d.package.newSub('rule', ''),
+    '#withTitle': { ignore: true },
+    '#withName': super['#withTitle'],
+    withName: super.withTitle,
+  },
+}

--- a/gen/grafonnet-v10.1.0/docs/README.md
+++ b/gen/grafonnet-v10.1.0/docs/README.md
@@ -17,6 +17,7 @@ local grafonnet = import "github.com/grafana/grafonnet/gen/grafonnet-v10.1.0/mai
 ## Subpackages
 
 * [accesspolicy](accesspolicy/index.md)
+* [alerting](alerting/index.md)
 * [dashboard](dashboard/index.md)
 * [folder](folder.md)
 * [librarypanel](librarypanel.md)

--- a/gen/grafonnet-v10.1.0/docs/alerting/contactPoint.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/contactPoint.md
@@ -1,0 +1,100 @@
+# contactPoint
+
+grafonnet.alerting.contactPoint
+
+**NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+
+
+## Index
+
+* [`fn withDisableResolveMessage(value=true)`](#fn-withdisableresolvemessage)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withProvenance(value)`](#fn-withprovenance)
+* [`fn withSettings(value)`](#fn-withsettings)
+* [`fn withSettingsMixin(value)`](#fn-withsettingsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withUid(value)`](#fn-withuid)
+
+## Fields
+
+### fn withDisableResolveMessage
+
+```jsonnet
+withDisableResolveMessage(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Name is used as grouping key in the UI. Contact points with the
+same name will be grouped in the UI.
+### fn withProvenance
+
+```jsonnet
+withProvenance(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSettings
+
+```jsonnet
+withSettings(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withSettingsMixin
+
+```jsonnet
+withSettingsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"alertmanager"`, `" dingding"`, `" discord"`, `" email"`, `" googlechat"`, `" kafka"`, `" line"`, `" opsgenie"`, `" pagerduty"`, `" pushover"`, `" sensugo"`, `" slack"`, `" teams"`, `" telegram"`, `" threema"`, `" victorops"`, `" webhook"`, `" wecom"`
+
+
+### fn withUid
+
+```jsonnet
+withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+UID is the unique identifier of the contact point. The UID can be
+set by the user.

--- a/gen/grafonnet-v10.1.0/docs/alerting/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/index.md
@@ -1,0 +1,11 @@
+# alerting
+
+grafonnet.alerting
+
+## Subpackages
+
+* [contactPoint](contactPoint.md)
+* [messageTemplate](messageTemplate.md)
+* [muteTiming](muteTiming/index.md)
+* [notificationPolicy](notificationPolicy/index.md)
+* [ruleGroup](ruleGroup/index.md)

--- a/gen/grafonnet-v10.1.0/docs/alerting/messageTemplate.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/messageTemplate.md
@@ -1,0 +1,32 @@
+# messageTemplate
+
+grafonnet.alerting.messageTemplate
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withTemplate(value)`](#fn-withtemplate)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTemplate
+
+```jsonnet
+withTemplate(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/index.md
@@ -1,0 +1,48 @@
+# muteTiming
+
+grafonnet.alerting.muteTiming
+
+## Subpackages
+
+* [interval](interval/index.md)
+
+## Index
+
+* [`fn withIntervals(value)`](#fn-withintervals)
+* [`fn withIntervalsMixin(value)`](#fn-withintervalsmixin)
+* [`fn withName(value)`](#fn-withname)
+
+## Fields
+
+### fn withIntervals
+
+```jsonnet
+withIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withIntervalsMixin
+
+```jsonnet
+withIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/interval/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/interval/index.md
@@ -1,0 +1,144 @@
+# interval
+
+
+
+## Subpackages
+
+* [times](times.md)
+
+## Index
+
+* [`fn withDaysOfMonth(value)`](#fn-withdaysofmonth)
+* [`fn withDaysOfMonthMixin(value)`](#fn-withdaysofmonthmixin)
+* [`fn withLocation(value)`](#fn-withlocation)
+* [`fn withMonths(value)`](#fn-withmonths)
+* [`fn withMonthsMixin(value)`](#fn-withmonthsmixin)
+* [`fn withTimes(value)`](#fn-withtimes)
+* [`fn withTimesMixin(value)`](#fn-withtimesmixin)
+* [`fn withWeekdays(value)`](#fn-withweekdays)
+* [`fn withWeekdaysMixin(value)`](#fn-withweekdaysmixin)
+* [`fn withYears(value)`](#fn-withyears)
+* [`fn withYearsMixin(value)`](#fn-withyearsmixin)
+
+## Fields
+
+### fn withDaysOfMonth
+
+```jsonnet
+withDaysOfMonth(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDaysOfMonthMixin
+
+```jsonnet
+withDaysOfMonthMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withLocation
+
+```jsonnet
+withLocation(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMonths
+
+```jsonnet
+withMonths(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMonthsMixin
+
+```jsonnet
+withMonthsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimes
+
+```jsonnet
+withTimes(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimesMixin
+
+```jsonnet
+withTimesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdays
+
+```jsonnet
+withWeekdays(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdaysMixin
+
+```jsonnet
+withWeekdaysMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYears
+
+```jsonnet
+withYears(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYearsMixin
+
+```jsonnet
+withYearsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/interval/times.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/muteTiming/interval/times.md
@@ -1,0 +1,32 @@
+# times
+
+
+
+## Index
+
+* [`fn withFrom(value)`](#fn-withfrom)
+* [`fn withTo(value)`](#fn-withto)
+
+## Fields
+
+### fn withFrom
+
+```jsonnet
+withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTo
+
+```jsonnet
+withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/notificationPolicy/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/notificationPolicy/index.md
@@ -1,0 +1,173 @@
+# notificationPolicy
+
+grafonnet.alerting.notificationPolicy
+
+## Subpackages
+
+* [matcher](matcher.md)
+
+## Index
+
+* [`fn withContactPoint(value)`](#fn-withcontactpoint)
+* [`fn withContinue(value=true)`](#fn-withcontinue)
+* [`fn withGroupBy(value)`](#fn-withgroupby)
+* [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
+* [`fn withGroupInterval(value)`](#fn-withgroupinterval)
+* [`fn withGroupWait(value)`](#fn-withgroupwait)
+* [`fn withMatchers(value)`](#fn-withmatchers)
+* [`fn withMatchersMixin(value)`](#fn-withmatchersmixin)
+* [`fn withMuteTimeIntervals(value)`](#fn-withmutetimeintervals)
+* [`fn withMuteTimeIntervalsMixin(value)`](#fn-withmutetimeintervalsmixin)
+* [`fn withPolicy(value)`](#fn-withpolicy)
+* [`fn withPolicyMixin(value)`](#fn-withpolicymixin)
+* [`fn withRepeatInterval(value)`](#fn-withrepeatinterval)
+
+## Fields
+
+### fn withContactPoint
+
+```jsonnet
+withContactPoint(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withContinue
+
+```jsonnet
+withContinue(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withGroupBy
+
+```jsonnet
+withGroupBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupByMixin
+
+```jsonnet
+withGroupByMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupInterval
+
+```jsonnet
+withGroupInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withGroupWait
+
+```jsonnet
+withGroupWait(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMatchers
+
+```jsonnet
+withMatchers(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMatchersMixin
+
+```jsonnet
+withMatchersMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMuteTimeIntervals
+
+```jsonnet
+withMuteTimeIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMuteTimeIntervalsMixin
+
+```jsonnet
+withMuteTimeIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicy
+
+```jsonnet
+withPolicy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicyMixin
+
+```jsonnet
+withPolicyMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRepeatInterval
+
+```jsonnet
+withRepeatInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/notificationPolicy/matcher.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/notificationPolicy/matcher.md
@@ -1,0 +1,45 @@
+# matcher
+
+
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withValue(value)`](#fn-withvalue)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"="`, `"!="`, `"=~"`, `"!~"`
+
+MatchType is an enum for label matching types.
+### fn withValue
+
+```jsonnet
+withValue(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/index.md
@@ -1,0 +1,72 @@
+# ruleGroup
+
+grafonnet.alerting.ruleGroup
+
+## Subpackages
+
+* [rule](rule/index.md)
+
+## Index
+
+* [`fn withFolderUid(value)`](#fn-withfolderuid)
+* [`fn withInterval(value)`](#fn-withinterval)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRules(value)`](#fn-withrules)
+* [`fn withRulesMixin(value)`](#fn-withrulesmixin)
+
+## Fields
+
+### fn withFolderUid
+
+```jsonnet
+withFolderUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withInterval
+
+```jsonnet
+withInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withRules
+
+```jsonnet
+withRules(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRulesMixin
+
+```jsonnet
+withRulesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/rule/data.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/rule/data.md
@@ -1,0 +1,128 @@
+# data
+
+
+
+## Index
+
+* [`fn withDatasourceUid(value)`](#fn-withdatasourceuid)
+* [`fn withModel(value)`](#fn-withmodel)
+* [`fn withModelMixin(value)`](#fn-withmodelmixin)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withRelativeTimeRange(value)`](#fn-withrelativetimerange)
+* [`fn withRelativeTimeRangeMixin(value)`](#fn-withrelativetimerangemixin)
+* [`obj relativeTimeRange`](#obj-relativetimerange)
+  * [`fn withFrom(value)`](#fn-relativetimerangewithfrom)
+  * [`fn withTo(value)`](#fn-relativetimerangewithto)
+
+## Fields
+
+### fn withDatasourceUid
+
+```jsonnet
+withDatasourceUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation.
+### fn withModel
+
+```jsonnet
+withModel(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withModelMixin
+
+```jsonnet
+withModelMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+RefID is the unique identifier of the query, set by the frontend call.
+### fn withRelativeTimeRange
+
+```jsonnet
+withRelativeTimeRange(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### fn withRelativeTimeRangeMixin
+
+```jsonnet
+withRelativeTimeRangeMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### obj relativeTimeRange
+
+
+#### fn relativeTimeRange.withFrom
+
+```jsonnet
+relativeTimeRange.withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+#### fn relativeTimeRange.withTo
+
+```jsonnet
+relativeTimeRange.withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.

--- a/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/rule/index.md
+++ b/gen/grafonnet-v10.1.0/docs/alerting/ruleGroup/rule/index.md
@@ -1,0 +1,161 @@
+# rule
+
+
+
+## Subpackages
+
+* [data](data.md)
+
+## Index
+
+* [`fn withAnnotations(value)`](#fn-withannotations)
+* [`fn withAnnotationsMixin(value)`](#fn-withannotationsmixin)
+* [`fn withCondition(value)`](#fn-withcondition)
+* [`fn withData(value)`](#fn-withdata)
+* [`fn withDataMixin(value)`](#fn-withdatamixin)
+* [`fn withExecErrState(value)`](#fn-withexecerrstate)
+* [`fn withFor(value)`](#fn-withfor)
+* [`fn withIsPaused(value=true)`](#fn-withispaused)
+* [`fn withLabels(value)`](#fn-withlabels)
+* [`fn withLabelsMixin(value)`](#fn-withlabelsmixin)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withNoDataState(value)`](#fn-withnodatastate)
+
+## Fields
+
+### fn withAnnotations
+
+```jsonnet
+withAnnotations(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withAnnotationsMixin
+
+```jsonnet
+withAnnotationsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withCondition
+
+```jsonnet
+withCondition(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withData
+
+```jsonnet
+withData(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDataMixin
+
+```jsonnet
+withDataMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withExecErrState
+
+```jsonnet
+withExecErrState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"OK"`, `"Alerting"`, `"Error"`
+
+
+### fn withFor
+
+```jsonnet
+withFor(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+### fn withIsPaused
+
+```jsonnet
+withIsPaused(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withLabels
+
+```jsonnet
+withLabels(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withLabelsMixin
+
+```jsonnet
+withLabelsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withNoDataState
+
+```jsonnet
+withNoDataState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"NoData"`, `"OK"`
+

--- a/gen/grafonnet-v10.1.0/main.libsonnet
+++ b/gen/grafonnet-v10.1.0/main.libsonnet
@@ -23,4 +23,5 @@
   panel: import 'panel.libsonnet',
   query: import 'query.libsonnet',
   util: import 'custom/util/main.libsonnet',
+  alerting: import 'alerting.libsonnet',
 }

--- a/gen/grafonnet-v10.1.0/raw/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v10.1.0/raw/alerting/contactPoint.libsonnet
@@ -1,0 +1,18 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}

--- a/gen/grafonnet-v10.1.0/raw/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v10.1.0/raw/alerting/messageTemplate.libsonnet
@@ -1,0 +1,10 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v10.1.0/raw/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v10.1.0/raw/alerting/muteTiming.libsonnet
@@ -1,0 +1,68 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  time_intervals+:
+    {
+      '#': { help: '', name: 'time_intervals' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withFrom(value): { from: value },
+          '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+          withTo(value): { to: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}

--- a/gen/grafonnet-v10.1.0/raw/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v10.1.0/raw/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,84 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withMatch': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatch(value): { match: value },
+  '#withMatchMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatchMixin(value): { match+: value },
+  '#withMatchRe': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchRe(value): { match_re: value },
+  '#withMatchReMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchReMixin(value): { match_re+: value },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  matchers+:
+    {
+      '#': { help: '', name: 'matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withObjectMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchers(value): { object_matchers: (if std.isArray(value)
+                                                 then value
+                                                 else [value]) },
+  '#withObjectMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchersMixin(value): { object_matchers+: (if std.isArray(value)
+                                                       then value
+                                                       else [value]) },
+  object_matchers+:
+    {
+      '#': { help: '', name: 'object_matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+}

--- a/gen/grafonnet-v10.1.0/raw/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v10.1.0/raw/alerting/ruleGroup.libsonnet
@@ -1,0 +1,89 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  rules+:
+    {
+      '#': { help: '', name: 'rules' },
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['OK', 'Alerting', 'Error'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFolderUID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withFolderUID(value): { folderUID: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withId(value): { id: value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withOrgID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withOrgID(value): { orgID: value },
+      '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withProvenance(value): { provenance: value },
+      '#withRuleGroup': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withRuleGroup(value): { ruleGroup: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUid(value): { uid: value },
+      '#withUpdated': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUpdated(value): { updated: value },
+    },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+}

--- a/gen/grafonnet-v9.4.0/alerting.libsonnet
+++ b/gen/grafonnet-v9.4.0/alerting.libsonnet
@@ -1,0 +1,9 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting', name: 'alerting' },
+  contactPoint: import 'clean/alerting/contactPoint.libsonnet',
+  notificationPolicy: import 'clean/alerting/notificationPolicy.libsonnet',
+  muteTiming: import 'clean/alerting/muteTiming.libsonnet',
+  ruleGroup: import 'clean/alerting/ruleGroup.libsonnet',
+  messageTemplate: import 'clean/alerting/messageTemplate.libsonnet',
+}

--- a/gen/grafonnet-v9.4.0/clean/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.4.0/clean/alerting/contactPoint.libsonnet
@@ -1,0 +1,19 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}
++ (import '../../custom/alerting/contactPoint.libsonnet')

--- a/gen/grafonnet-v9.4.0/clean/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v9.4.0/clean/alerting/messageTemplate.libsonnet
@@ -1,0 +1,8 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v9.4.0/clean/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.4.0/clean/alerting/muteTiming.libsonnet
@@ -1,0 +1,69 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  interval+:
+    {
+      '#': { help: '', name: 'interval' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withEndMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withEndMinute(value): { EndMinute: value },
+          '#withStartMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withStartMinute(value): { StartMinute: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}
++ (import '../../custom/alerting/muteTiming.libsonnet')

--- a/gen/grafonnet-v9.4.0/clean/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.4.0/clean/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,57 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+  matcher+:
+    {
+      '#': { help: '', name: 'matcher' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+}
++ (import '../../custom/alerting/notificationPolicy.libsonnet')

--- a/gen/grafonnet-v9.4.0/clean/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.4.0/clean/alerting/ruleGroup.libsonnet
@@ -1,0 +1,75 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+  rule+:
+    {
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['Alerting', 'Error', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+    },
+}
++ (import '../../custom/alerting/ruleGroup.libsonnet')

--- a/gen/grafonnet-v9.4.0/custom/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/alerting/contactPoint.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#'+:: {
+    help+:
+      |||
+
+
+        **NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+      |||,
+  },
+}

--- a/gen/grafonnet-v9.4.0/custom/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/alerting/muteTiming.libsonnet
@@ -1,0 +1,8 @@
+{
+  '#withTimeIntervals': { ignore: true },
+  '#withIntervals': super['#withTimeIntervals'],
+  withIntervals: super.withTimeIntervals,
+  '#withTimeIntervalsMixin': { ignore: true },
+  '#withIntervalsMixin': super['#withTimeIntervalsMixin'],
+  withIntervalsMixin: super.withTimeIntervalsMixin,
+}

--- a/gen/grafonnet-v9.4.0/custom/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,12 @@
+{
+  '#withReceiver': { ignore: true },
+  '#withContactPoint': super['#withReceiver'],
+  withContactPoint: super.withReceiver,
+
+  '#withRoutes': { ignore: true },
+  '#withPolicy': super['#withRoutes'],
+  withPolicy: super.withRoutes,
+  '#withRoutesMixin': { ignore: true },
+  '#withPolicyMixin': super['#withRoutesMixin'],
+  withPolicyMixin: super.withRoutesMixin,
+}

--- a/gen/grafonnet-v9.4.0/custom/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/alerting/ruleGroup.libsonnet
@@ -1,0 +1,13 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#withTitle': { ignore: true },
+  '#withName': super['#withTitle'],
+  withName: super.withTitle,
+  rule+: {
+    '#':: d.package.newSub('rule', ''),
+    '#withTitle': { ignore: true },
+    '#withName': super['#withTitle'],
+    withName: super.withTitle,
+  },
+}

--- a/gen/grafonnet-v9.4.0/docs/README.md
+++ b/gen/grafonnet-v9.4.0/docs/README.md
@@ -16,6 +16,7 @@ local grafonnet = import "github.com/grafana/grafonnet/gen/grafonnet-v9.4.0/main
 
 ## Subpackages
 
+* [alerting](alerting/index.md)
 * [dashboard](dashboard/index.md)
 * [librarypanel](librarypanel.md)
 * [panel](panel/index.md)

--- a/gen/grafonnet-v9.4.0/docs/alerting/contactPoint.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/contactPoint.md
@@ -1,0 +1,100 @@
+# contactPoint
+
+grafonnet.alerting.contactPoint
+
+**NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+
+
+## Index
+
+* [`fn withDisableResolveMessage(value=true)`](#fn-withdisableresolvemessage)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withProvenance(value)`](#fn-withprovenance)
+* [`fn withSettings(value)`](#fn-withsettings)
+* [`fn withSettingsMixin(value)`](#fn-withsettingsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withUid(value)`](#fn-withuid)
+
+## Fields
+
+### fn withDisableResolveMessage
+
+```jsonnet
+withDisableResolveMessage(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Name is used as grouping key in the UI. Contact points with the
+same name will be grouped in the UI.
+### fn withProvenance
+
+```jsonnet
+withProvenance(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSettings
+
+```jsonnet
+withSettings(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withSettingsMixin
+
+```jsonnet
+withSettingsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"alertmanager"`, `" dingding"`, `" discord"`, `" email"`, `" googlechat"`, `" kafka"`, `" line"`, `" opsgenie"`, `" pagerduty"`, `" pushover"`, `" sensugo"`, `" slack"`, `" teams"`, `" telegram"`, `" threema"`, `" victorops"`, `" webhook"`, `" wecom"`
+
+
+### fn withUid
+
+```jsonnet
+withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+UID is the unique identifier of the contact point. The UID can be
+set by the user.

--- a/gen/grafonnet-v9.4.0/docs/alerting/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/index.md
@@ -1,0 +1,11 @@
+# alerting
+
+grafonnet.alerting
+
+## Subpackages
+
+* [contactPoint](contactPoint.md)
+* [messageTemplate](messageTemplate.md)
+* [muteTiming](muteTiming/index.md)
+* [notificationPolicy](notificationPolicy/index.md)
+* [ruleGroup](ruleGroup/index.md)

--- a/gen/grafonnet-v9.4.0/docs/alerting/messageTemplate.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/messageTemplate.md
@@ -1,0 +1,32 @@
+# messageTemplate
+
+grafonnet.alerting.messageTemplate
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withTemplate(value)`](#fn-withtemplate)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTemplate
+
+```jsonnet
+withTemplate(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/index.md
@@ -1,0 +1,48 @@
+# muteTiming
+
+grafonnet.alerting.muteTiming
+
+## Subpackages
+
+* [interval](interval/index.md)
+
+## Index
+
+* [`fn withIntervals(value)`](#fn-withintervals)
+* [`fn withIntervalsMixin(value)`](#fn-withintervalsmixin)
+* [`fn withName(value)`](#fn-withname)
+
+## Fields
+
+### fn withIntervals
+
+```jsonnet
+withIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withIntervalsMixin
+
+```jsonnet
+withIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/interval/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/interval/index.md
@@ -1,0 +1,144 @@
+# interval
+
+
+
+## Subpackages
+
+* [times](times.md)
+
+## Index
+
+* [`fn withDaysOfMonth(value)`](#fn-withdaysofmonth)
+* [`fn withDaysOfMonthMixin(value)`](#fn-withdaysofmonthmixin)
+* [`fn withLocation(value)`](#fn-withlocation)
+* [`fn withMonths(value)`](#fn-withmonths)
+* [`fn withMonthsMixin(value)`](#fn-withmonthsmixin)
+* [`fn withTimes(value)`](#fn-withtimes)
+* [`fn withTimesMixin(value)`](#fn-withtimesmixin)
+* [`fn withWeekdays(value)`](#fn-withweekdays)
+* [`fn withWeekdaysMixin(value)`](#fn-withweekdaysmixin)
+* [`fn withYears(value)`](#fn-withyears)
+* [`fn withYearsMixin(value)`](#fn-withyearsmixin)
+
+## Fields
+
+### fn withDaysOfMonth
+
+```jsonnet
+withDaysOfMonth(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDaysOfMonthMixin
+
+```jsonnet
+withDaysOfMonthMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withLocation
+
+```jsonnet
+withLocation(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMonths
+
+```jsonnet
+withMonths(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMonthsMixin
+
+```jsonnet
+withMonthsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimes
+
+```jsonnet
+withTimes(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimesMixin
+
+```jsonnet
+withTimesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdays
+
+```jsonnet
+withWeekdays(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdaysMixin
+
+```jsonnet
+withWeekdaysMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYears
+
+```jsonnet
+withYears(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYearsMixin
+
+```jsonnet
+withYearsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/interval/times.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/muteTiming/interval/times.md
@@ -1,0 +1,32 @@
+# times
+
+
+
+## Index
+
+* [`fn withEndMinute(value)`](#fn-withendminute)
+* [`fn withStartMinute(value)`](#fn-withstartminute)
+
+## Fields
+
+### fn withEndMinute
+
+```jsonnet
+withEndMinute(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withStartMinute
+
+```jsonnet
+withStartMinute(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/notificationPolicy/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/notificationPolicy/index.md
@@ -1,0 +1,173 @@
+# notificationPolicy
+
+grafonnet.alerting.notificationPolicy
+
+## Subpackages
+
+* [matcher](matcher.md)
+
+## Index
+
+* [`fn withContactPoint(value)`](#fn-withcontactpoint)
+* [`fn withContinue(value=true)`](#fn-withcontinue)
+* [`fn withGroupBy(value)`](#fn-withgroupby)
+* [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
+* [`fn withGroupInterval(value)`](#fn-withgroupinterval)
+* [`fn withGroupWait(value)`](#fn-withgroupwait)
+* [`fn withMatchers(value)`](#fn-withmatchers)
+* [`fn withMatchersMixin(value)`](#fn-withmatchersmixin)
+* [`fn withMuteTimeIntervals(value)`](#fn-withmutetimeintervals)
+* [`fn withMuteTimeIntervalsMixin(value)`](#fn-withmutetimeintervalsmixin)
+* [`fn withPolicy(value)`](#fn-withpolicy)
+* [`fn withPolicyMixin(value)`](#fn-withpolicymixin)
+* [`fn withRepeatInterval(value)`](#fn-withrepeatinterval)
+
+## Fields
+
+### fn withContactPoint
+
+```jsonnet
+withContactPoint(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withContinue
+
+```jsonnet
+withContinue(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withGroupBy
+
+```jsonnet
+withGroupBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupByMixin
+
+```jsonnet
+withGroupByMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupInterval
+
+```jsonnet
+withGroupInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withGroupWait
+
+```jsonnet
+withGroupWait(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMatchers
+
+```jsonnet
+withMatchers(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMatchersMixin
+
+```jsonnet
+withMatchersMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMuteTimeIntervals
+
+```jsonnet
+withMuteTimeIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMuteTimeIntervalsMixin
+
+```jsonnet
+withMuteTimeIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicy
+
+```jsonnet
+withPolicy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicyMixin
+
+```jsonnet
+withPolicyMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRepeatInterval
+
+```jsonnet
+withRepeatInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/notificationPolicy/matcher.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/notificationPolicy/matcher.md
@@ -1,0 +1,45 @@
+# matcher
+
+
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withValue(value)`](#fn-withvalue)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"="`, `"!="`, `"=~"`, `"!~"`
+
+MatchType is an enum for label matching types.
+### fn withValue
+
+```jsonnet
+withValue(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/index.md
@@ -1,0 +1,72 @@
+# ruleGroup
+
+grafonnet.alerting.ruleGroup
+
+## Subpackages
+
+* [rule](rule/index.md)
+
+## Index
+
+* [`fn withFolderUid(value)`](#fn-withfolderuid)
+* [`fn withInterval(value)`](#fn-withinterval)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRules(value)`](#fn-withrules)
+* [`fn withRulesMixin(value)`](#fn-withrulesmixin)
+
+## Fields
+
+### fn withFolderUid
+
+```jsonnet
+withFolderUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withInterval
+
+```jsonnet
+withInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withRules
+
+```jsonnet
+withRules(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRulesMixin
+
+```jsonnet
+withRulesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/rule/data.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/rule/data.md
@@ -1,0 +1,128 @@
+# data
+
+
+
+## Index
+
+* [`fn withDatasourceUid(value)`](#fn-withdatasourceuid)
+* [`fn withModel(value)`](#fn-withmodel)
+* [`fn withModelMixin(value)`](#fn-withmodelmixin)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withRelativeTimeRange(value)`](#fn-withrelativetimerange)
+* [`fn withRelativeTimeRangeMixin(value)`](#fn-withrelativetimerangemixin)
+* [`obj relativeTimeRange`](#obj-relativetimerange)
+  * [`fn withFrom(value)`](#fn-relativetimerangewithfrom)
+  * [`fn withTo(value)`](#fn-relativetimerangewithto)
+
+## Fields
+
+### fn withDatasourceUid
+
+```jsonnet
+withDatasourceUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation.
+### fn withModel
+
+```jsonnet
+withModel(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withModelMixin
+
+```jsonnet
+withModelMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+RefID is the unique identifier of the query, set by the frontend call.
+### fn withRelativeTimeRange
+
+```jsonnet
+withRelativeTimeRange(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### fn withRelativeTimeRangeMixin
+
+```jsonnet
+withRelativeTimeRangeMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### obj relativeTimeRange
+
+
+#### fn relativeTimeRange.withFrom
+
+```jsonnet
+relativeTimeRange.withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+#### fn relativeTimeRange.withTo
+
+```jsonnet
+relativeTimeRange.withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.

--- a/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/rule/index.md
+++ b/gen/grafonnet-v9.4.0/docs/alerting/ruleGroup/rule/index.md
@@ -1,0 +1,161 @@
+# rule
+
+
+
+## Subpackages
+
+* [data](data.md)
+
+## Index
+
+* [`fn withAnnotations(value)`](#fn-withannotations)
+* [`fn withAnnotationsMixin(value)`](#fn-withannotationsmixin)
+* [`fn withCondition(value)`](#fn-withcondition)
+* [`fn withData(value)`](#fn-withdata)
+* [`fn withDataMixin(value)`](#fn-withdatamixin)
+* [`fn withExecErrState(value)`](#fn-withexecerrstate)
+* [`fn withFor(value)`](#fn-withfor)
+* [`fn withIsPaused(value=true)`](#fn-withispaused)
+* [`fn withLabels(value)`](#fn-withlabels)
+* [`fn withLabelsMixin(value)`](#fn-withlabelsmixin)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withNoDataState(value)`](#fn-withnodatastate)
+
+## Fields
+
+### fn withAnnotations
+
+```jsonnet
+withAnnotations(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withAnnotationsMixin
+
+```jsonnet
+withAnnotationsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withCondition
+
+```jsonnet
+withCondition(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withData
+
+```jsonnet
+withData(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDataMixin
+
+```jsonnet
+withDataMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withExecErrState
+
+```jsonnet
+withExecErrState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"Error"`, `"OK"`
+
+
+### fn withFor
+
+```jsonnet
+withFor(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+A Duration represents the elapsed time between two instants
+as an int64 nanosecond count. The representation limits the
+largest representable duration to approximately 290 years.
+### fn withIsPaused
+
+```jsonnet
+withIsPaused(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withLabels
+
+```jsonnet
+withLabels(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withLabelsMixin
+
+```jsonnet
+withLabelsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withNoDataState
+
+```jsonnet
+withNoDataState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"NoData"`, `"OK"`
+

--- a/gen/grafonnet-v9.4.0/main.libsonnet
+++ b/gen/grafonnet-v9.4.0/main.libsonnet
@@ -20,4 +20,5 @@
   panel: import 'panel.libsonnet',
   query: import 'query.libsonnet',
   util: import 'custom/util/main.libsonnet',
+  alerting: import 'alerting.libsonnet',
 }

--- a/gen/grafonnet-v9.4.0/raw/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.4.0/raw/alerting/contactPoint.libsonnet
@@ -1,0 +1,18 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}

--- a/gen/grafonnet-v9.4.0/raw/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v9.4.0/raw/alerting/messageTemplate.libsonnet
@@ -1,0 +1,10 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v9.4.0/raw/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.4.0/raw/alerting/muteTiming.libsonnet
@@ -1,0 +1,68 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  time_intervals+:
+    {
+      '#': { help: '', name: 'time_intervals' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withEndMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withEndMinute(value): { EndMinute: value },
+          '#withStartMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withStartMinute(value): { StartMinute: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}

--- a/gen/grafonnet-v9.4.0/raw/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.4.0/raw/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,84 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withMatch': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatch(value): { match: value },
+  '#withMatchMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatchMixin(value): { match+: value },
+  '#withMatchRe': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchRe(value): { match_re: value },
+  '#withMatchReMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchReMixin(value): { match_re+: value },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  matchers+:
+    {
+      '#': { help: '', name: 'matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withObjectMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchers(value): { object_matchers: (if std.isArray(value)
+                                                 then value
+                                                 else [value]) },
+  '#withObjectMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchersMixin(value): { object_matchers+: (if std.isArray(value)
+                                                       then value
+                                                       else [value]) },
+  object_matchers+:
+    {
+      '#': { help: '', name: 'object_matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+}

--- a/gen/grafonnet-v9.4.0/raw/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.4.0/raw/alerting/ruleGroup.libsonnet
@@ -1,0 +1,89 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  rules+:
+    {
+      '#': { help: '', name: 'rules' },
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['Alerting', 'Error', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFolderUID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withFolderUID(value): { folderUID: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.' } },
+      withFor(value): { 'for': value },
+      '#withId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withId(value): { id: value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withOrgID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withOrgID(value): { orgID: value },
+      '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withProvenance(value): { provenance: value },
+      '#withRuleGroup': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withRuleGroup(value): { ruleGroup: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUid(value): { uid: value },
+      '#withUpdated': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUpdated(value): { updated: value },
+    },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+}

--- a/gen/grafonnet-v9.5.0/alerting.libsonnet
+++ b/gen/grafonnet-v9.5.0/alerting.libsonnet
@@ -1,0 +1,9 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting', name: 'alerting' },
+  contactPoint: import 'clean/alerting/contactPoint.libsonnet',
+  notificationPolicy: import 'clean/alerting/notificationPolicy.libsonnet',
+  muteTiming: import 'clean/alerting/muteTiming.libsonnet',
+  ruleGroup: import 'clean/alerting/ruleGroup.libsonnet',
+  messageTemplate: import 'clean/alerting/messageTemplate.libsonnet',
+}

--- a/gen/grafonnet-v9.5.0/clean/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.5.0/clean/alerting/contactPoint.libsonnet
@@ -1,0 +1,19 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}
++ (import '../../custom/alerting/contactPoint.libsonnet')

--- a/gen/grafonnet-v9.5.0/clean/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v9.5.0/clean/alerting/messageTemplate.libsonnet
@@ -1,0 +1,8 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v9.5.0/clean/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.5.0/clean/alerting/muteTiming.libsonnet
@@ -1,0 +1,69 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  interval+:
+    {
+      '#': { help: '', name: 'interval' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withEndMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withEndMinute(value): { EndMinute: value },
+          '#withStartMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withStartMinute(value): { StartMinute: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}
++ (import '../../custom/alerting/muteTiming.libsonnet')

--- a/gen/grafonnet-v9.5.0/clean/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.5.0/clean/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,57 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+  matcher+:
+    {
+      '#': { help: '', name: 'matcher' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+}
++ (import '../../custom/alerting/notificationPolicy.libsonnet')

--- a/gen/grafonnet-v9.5.0/clean/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.5.0/clean/alerting/ruleGroup.libsonnet
@@ -1,0 +1,75 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+  rule+:
+    {
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['Alerting', 'Error', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+      withFor(value): { 'for': value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+    },
+}
++ (import '../../custom/alerting/ruleGroup.libsonnet')

--- a/gen/grafonnet-v9.5.0/custom/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/alerting/contactPoint.libsonnet
@@ -1,0 +1,12 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#'+:: {
+    help+:
+      |||
+
+
+        **NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+      |||,
+  },
+}

--- a/gen/grafonnet-v9.5.0/custom/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/alerting/muteTiming.libsonnet
@@ -1,0 +1,8 @@
+{
+  '#withTimeIntervals': { ignore: true },
+  '#withIntervals': super['#withTimeIntervals'],
+  withIntervals: super.withTimeIntervals,
+  '#withTimeIntervalsMixin': { ignore: true },
+  '#withIntervalsMixin': super['#withTimeIntervalsMixin'],
+  withIntervalsMixin: super.withTimeIntervalsMixin,
+}

--- a/gen/grafonnet-v9.5.0/custom/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,12 @@
+{
+  '#withReceiver': { ignore: true },
+  '#withContactPoint': super['#withReceiver'],
+  withContactPoint: super.withReceiver,
+
+  '#withRoutes': { ignore: true },
+  '#withPolicy': super['#withRoutes'],
+  withPolicy: super.withRoutes,
+  '#withRoutesMixin': { ignore: true },
+  '#withPolicyMixin': super['#withRoutesMixin'],
+  withPolicyMixin: super.withRoutesMixin,
+}

--- a/gen/grafonnet-v9.5.0/custom/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/alerting/ruleGroup.libsonnet
@@ -1,0 +1,13 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#withTitle': { ignore: true },
+  '#withName': super['#withTitle'],
+  withName: super.withTitle,
+  rule+: {
+    '#':: d.package.newSub('rule', ''),
+    '#withTitle': { ignore: true },
+    '#withName': super['#withTitle'],
+    withName: super.withTitle,
+  },
+}

--- a/gen/grafonnet-v9.5.0/docs/README.md
+++ b/gen/grafonnet-v9.5.0/docs/README.md
@@ -16,6 +16,7 @@ local grafonnet = import "github.com/grafana/grafonnet/gen/grafonnet-v9.5.0/main
 
 ## Subpackages
 
+* [alerting](alerting/index.md)
 * [dashboard](dashboard/index.md)
 * [librarypanel](librarypanel.md)
 * [panel](panel/index.md)

--- a/gen/grafonnet-v9.5.0/docs/alerting/contactPoint.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/contactPoint.md
@@ -1,0 +1,100 @@
+# contactPoint
+
+grafonnet.alerting.contactPoint
+
+**NOTE**: The schemas for all different contact points is under development, this means we can't properly express them in Grafonnet yet. The way this works now may change heavily.
+
+
+## Index
+
+* [`fn withDisableResolveMessage(value=true)`](#fn-withdisableresolvemessage)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withProvenance(value)`](#fn-withprovenance)
+* [`fn withSettings(value)`](#fn-withsettings)
+* [`fn withSettingsMixin(value)`](#fn-withsettingsmixin)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withUid(value)`](#fn-withuid)
+
+## Fields
+
+### fn withDisableResolveMessage
+
+```jsonnet
+withDisableResolveMessage(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Name is used as grouping key in the UI. Contact points with the
+same name will be grouped in the UI.
+### fn withProvenance
+
+```jsonnet
+withProvenance(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withSettings
+
+```jsonnet
+withSettings(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withSettingsMixin
+
+```jsonnet
+withSettingsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"alertmanager"`, `" dingding"`, `" discord"`, `" email"`, `" googlechat"`, `" kafka"`, `" line"`, `" opsgenie"`, `" pagerduty"`, `" pushover"`, `" sensugo"`, `" slack"`, `" teams"`, `" telegram"`, `" threema"`, `" victorops"`, `" webhook"`, `" wecom"`
+
+
+### fn withUid
+
+```jsonnet
+withUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+UID is the unique identifier of the contact point. The UID can be
+set by the user.

--- a/gen/grafonnet-v9.5.0/docs/alerting/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/index.md
@@ -1,0 +1,11 @@
+# alerting
+
+grafonnet.alerting
+
+## Subpackages
+
+* [contactPoint](contactPoint.md)
+* [messageTemplate](messageTemplate.md)
+* [muteTiming](muteTiming/index.md)
+* [notificationPolicy](notificationPolicy/index.md)
+* [ruleGroup](ruleGroup/index.md)

--- a/gen/grafonnet-v9.5.0/docs/alerting/messageTemplate.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/messageTemplate.md
@@ -1,0 +1,32 @@
+# messageTemplate
+
+grafonnet.alerting.messageTemplate
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withTemplate(value)`](#fn-withtemplate)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withTemplate
+
+```jsonnet
+withTemplate(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/index.md
@@ -1,0 +1,48 @@
+# muteTiming
+
+grafonnet.alerting.muteTiming
+
+## Subpackages
+
+* [interval](interval/index.md)
+
+## Index
+
+* [`fn withIntervals(value)`](#fn-withintervals)
+* [`fn withIntervalsMixin(value)`](#fn-withintervalsmixin)
+* [`fn withName(value)`](#fn-withname)
+
+## Fields
+
+### fn withIntervals
+
+```jsonnet
+withIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withIntervalsMixin
+
+```jsonnet
+withIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/interval/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/interval/index.md
@@ -1,0 +1,144 @@
+# interval
+
+
+
+## Subpackages
+
+* [times](times.md)
+
+## Index
+
+* [`fn withDaysOfMonth(value)`](#fn-withdaysofmonth)
+* [`fn withDaysOfMonthMixin(value)`](#fn-withdaysofmonthmixin)
+* [`fn withLocation(value)`](#fn-withlocation)
+* [`fn withMonths(value)`](#fn-withmonths)
+* [`fn withMonthsMixin(value)`](#fn-withmonthsmixin)
+* [`fn withTimes(value)`](#fn-withtimes)
+* [`fn withTimesMixin(value)`](#fn-withtimesmixin)
+* [`fn withWeekdays(value)`](#fn-withweekdays)
+* [`fn withWeekdaysMixin(value)`](#fn-withweekdaysmixin)
+* [`fn withYears(value)`](#fn-withyears)
+* [`fn withYearsMixin(value)`](#fn-withyearsmixin)
+
+## Fields
+
+### fn withDaysOfMonth
+
+```jsonnet
+withDaysOfMonth(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDaysOfMonthMixin
+
+```jsonnet
+withDaysOfMonthMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withLocation
+
+```jsonnet
+withLocation(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMonths
+
+```jsonnet
+withMonths(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMonthsMixin
+
+```jsonnet
+withMonthsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimes
+
+```jsonnet
+withTimes(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withTimesMixin
+
+```jsonnet
+withTimesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdays
+
+```jsonnet
+withWeekdays(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withWeekdaysMixin
+
+```jsonnet
+withWeekdaysMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYears
+
+```jsonnet
+withYears(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withYearsMixin
+
+```jsonnet
+withYearsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/interval/times.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/muteTiming/interval/times.md
@@ -1,0 +1,32 @@
+# times
+
+
+
+## Index
+
+* [`fn withEndMinute(value)`](#fn-withendminute)
+* [`fn withStartMinute(value)`](#fn-withstartminute)
+
+## Fields
+
+### fn withEndMinute
+
+```jsonnet
+withEndMinute(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withStartMinute
+
+```jsonnet
+withStartMinute(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/notificationPolicy/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/notificationPolicy/index.md
@@ -1,0 +1,173 @@
+# notificationPolicy
+
+grafonnet.alerting.notificationPolicy
+
+## Subpackages
+
+* [matcher](matcher.md)
+
+## Index
+
+* [`fn withContactPoint(value)`](#fn-withcontactpoint)
+* [`fn withContinue(value=true)`](#fn-withcontinue)
+* [`fn withGroupBy(value)`](#fn-withgroupby)
+* [`fn withGroupByMixin(value)`](#fn-withgroupbymixin)
+* [`fn withGroupInterval(value)`](#fn-withgroupinterval)
+* [`fn withGroupWait(value)`](#fn-withgroupwait)
+* [`fn withMatchers(value)`](#fn-withmatchers)
+* [`fn withMatchersMixin(value)`](#fn-withmatchersmixin)
+* [`fn withMuteTimeIntervals(value)`](#fn-withmutetimeintervals)
+* [`fn withMuteTimeIntervalsMixin(value)`](#fn-withmutetimeintervalsmixin)
+* [`fn withPolicy(value)`](#fn-withpolicy)
+* [`fn withPolicyMixin(value)`](#fn-withpolicymixin)
+* [`fn withRepeatInterval(value)`](#fn-withrepeatinterval)
+
+## Fields
+
+### fn withContactPoint
+
+```jsonnet
+withContactPoint(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withContinue
+
+```jsonnet
+withContinue(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withGroupBy
+
+```jsonnet
+withGroupBy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupByMixin
+
+```jsonnet
+withGroupByMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withGroupInterval
+
+```jsonnet
+withGroupInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withGroupWait
+
+```jsonnet
+withGroupWait(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withMatchers
+
+```jsonnet
+withMatchers(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMatchersMixin
+
+```jsonnet
+withMatchersMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+Matchers is a slice of Matchers that is sortable, implements Stringer, and
+provides a Matches method to match a LabelSet against all Matchers in the
+slice. Note that some users of Matchers might require it to be sorted.
+### fn withMuteTimeIntervals
+
+```jsonnet
+withMuteTimeIntervals(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withMuteTimeIntervalsMixin
+
+```jsonnet
+withMuteTimeIntervalsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicy
+
+```jsonnet
+withPolicy(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withPolicyMixin
+
+```jsonnet
+withPolicyMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRepeatInterval
+
+```jsonnet
+withRepeatInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/notificationPolicy/matcher.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/notificationPolicy/matcher.md
@@ -1,0 +1,45 @@
+# matcher
+
+
+
+## Index
+
+* [`fn withName(value)`](#fn-withname)
+* [`fn withType(value)`](#fn-withtype)
+* [`fn withValue(value)`](#fn-withvalue)
+
+## Fields
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withType
+
+```jsonnet
+withType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"="`, `"!="`, `"=~"`, `"!~"`
+
+MatchType is an enum for label matching types.
+### fn withValue
+
+```jsonnet
+withValue(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/index.md
@@ -1,0 +1,72 @@
+# ruleGroup
+
+grafonnet.alerting.ruleGroup
+
+## Subpackages
+
+* [rule](rule/index.md)
+
+## Index
+
+* [`fn withFolderUid(value)`](#fn-withfolderuid)
+* [`fn withInterval(value)`](#fn-withinterval)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withRules(value)`](#fn-withrules)
+* [`fn withRulesMixin(value)`](#fn-withrulesmixin)
+
+## Fields
+
+### fn withFolderUid
+
+```jsonnet
+withFolderUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withInterval
+
+```jsonnet
+withInterval(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withRules
+
+```jsonnet
+withRules(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withRulesMixin
+
+```jsonnet
+withRulesMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+

--- a/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/rule/data.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/rule/data.md
@@ -1,0 +1,124 @@
+# data
+
+
+
+## Index
+
+* [`fn withDatasourceUid(value)`](#fn-withdatasourceuid)
+* [`fn withModel(value)`](#fn-withmodel)
+* [`fn withModelMixin(value)`](#fn-withmodelmixin)
+* [`fn withQueryType(value)`](#fn-withquerytype)
+* [`fn withRefId(value)`](#fn-withrefid)
+* [`fn withRelativeTimeRange(value)`](#fn-withrelativetimerange)
+* [`fn withRelativeTimeRangeMixin(value)`](#fn-withrelativetimerangemixin)
+* [`obj relativeTimeRange`](#obj-relativetimerange)
+  * [`fn withFrom(value)`](#fn-relativetimerangewithfrom)
+  * [`fn withTo(value)`](#fn-relativetimerangewithto)
+
+## Fields
+
+### fn withDatasourceUid
+
+```jsonnet
+withDatasourceUid(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation.
+### fn withModel
+
+```jsonnet
+withModel(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withModelMixin
+
+```jsonnet
+withModelMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+JSON is the raw JSON query and includes the above properties as well as custom properties.
+### fn withQueryType
+
+```jsonnet
+withQueryType(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+QueryType is an optional identifier for the type of query.
+It can be used to distinguish different types of queries.
+### fn withRefId
+
+```jsonnet
+withRefId(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+RefID is the unique identifier of the query, set by the frontend call.
+### fn withRelativeTimeRange
+
+```jsonnet
+withRelativeTimeRange(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### fn withRelativeTimeRangeMixin
+
+```jsonnet
+withRelativeTimeRangeMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+RelativeTimeRange is the per query start and end time
+for requests.
+### obj relativeTimeRange
+
+
+#### fn relativeTimeRange.withFrom
+
+```jsonnet
+relativeTimeRange.withFrom(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+Duration is a type used for marshalling durations.
+#### fn relativeTimeRange.withTo
+
+```jsonnet
+relativeTimeRange.withTo(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+Duration is a type used for marshalling durations.

--- a/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/rule/index.md
+++ b/gen/grafonnet-v9.5.0/docs/alerting/ruleGroup/rule/index.md
@@ -1,0 +1,159 @@
+# rule
+
+
+
+## Subpackages
+
+* [data](data.md)
+
+## Index
+
+* [`fn withAnnotations(value)`](#fn-withannotations)
+* [`fn withAnnotationsMixin(value)`](#fn-withannotationsmixin)
+* [`fn withCondition(value)`](#fn-withcondition)
+* [`fn withData(value)`](#fn-withdata)
+* [`fn withDataMixin(value)`](#fn-withdatamixin)
+* [`fn withExecErrState(value)`](#fn-withexecerrstate)
+* [`fn withFor(value)`](#fn-withfor)
+* [`fn withIsPaused(value=true)`](#fn-withispaused)
+* [`fn withLabels(value)`](#fn-withlabels)
+* [`fn withLabelsMixin(value)`](#fn-withlabelsmixin)
+* [`fn withName(value)`](#fn-withname)
+* [`fn withNoDataState(value)`](#fn-withnodatastate)
+
+## Fields
+
+### fn withAnnotations
+
+```jsonnet
+withAnnotations(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withAnnotationsMixin
+
+```jsonnet
+withAnnotationsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withCondition
+
+```jsonnet
+withCondition(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withData
+
+```jsonnet
+withData(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withDataMixin
+
+```jsonnet
+withDataMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`array`)
+
+
+### fn withExecErrState
+
+```jsonnet
+withExecErrState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"Error"`, `"OK"`
+
+
+### fn withFor
+
+```jsonnet
+withFor(value)
+```
+
+PARAMETERS:
+
+* **value** (`integer`)
+
+Duration is a type used for marshalling durations.
+### fn withIsPaused
+
+```jsonnet
+withIsPaused(value=true)
+```
+
+PARAMETERS:
+
+* **value** (`boolean`)
+   - default value: `true`
+
+
+### fn withLabels
+
+```jsonnet
+withLabels(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withLabelsMixin
+
+```jsonnet
+withLabelsMixin(value)
+```
+
+PARAMETERS:
+
+* **value** (`object`)
+
+
+### fn withName
+
+```jsonnet
+withName(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+
+
+### fn withNoDataState
+
+```jsonnet
+withNoDataState(value)
+```
+
+PARAMETERS:
+
+* **value** (`string`)
+   - valid values: `"Alerting"`, `"NoData"`, `"OK"`
+

--- a/gen/grafonnet-v9.5.0/main.libsonnet
+++ b/gen/grafonnet-v9.5.0/main.libsonnet
@@ -20,4 +20,5 @@
   panel: import 'panel.libsonnet',
   query: import 'query.libsonnet',
   util: import 'custom/util/main.libsonnet',
+  alerting: import 'alerting.libsonnet',
 }

--- a/gen/grafonnet-v9.5.0/raw/alerting/contactPoint.libsonnet
+++ b/gen/grafonnet-v9.5.0/raw/alerting/contactPoint.libsonnet
@@ -1,0 +1,18 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.contactPoint', name: 'contactPoint' },
+  '#withDisableResolveMessage': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withDisableResolveMessage(value=true): { disableResolveMessage: value },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'Name is used as grouping key in the UI. Contact points with the\nsame name will be grouped in the UI.' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withSettings': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettings(value): { settings: value },
+  '#withSettingsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+  withSettingsMixin(value): { settings+: value },
+  '#withType': { 'function': { args: [{ default: null, enums: ['alertmanager', ' dingding', ' discord', ' email', ' googlechat', ' kafka', ' line', ' opsgenie', ' pagerduty', ' pushover', ' sensugo', ' slack', ' teams', ' telegram', ' threema', ' victorops', ' webhook', ' wecom'], name: 'value', type: 'string' }], help: '' } },
+  withType(value): { type: value },
+  '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'UID is the unique identifier of the contact point. The UID can be\nset by the user.' } },
+  withUid(value): { uid: value },
+}

--- a/gen/grafonnet-v9.5.0/raw/alerting/messageTemplate.libsonnet
+++ b/gen/grafonnet-v9.5.0/raw/alerting/messageTemplate.libsonnet
@@ -1,0 +1,10 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.messageTemplate', name: 'messageTemplate' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withTemplate': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTemplate(value): { template: value },
+}

--- a/gen/grafonnet-v9.5.0/raw/alerting/muteTiming.libsonnet
+++ b/gen/grafonnet-v9.5.0/raw/alerting/muteTiming.libsonnet
@@ -1,0 +1,68 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.muteTiming', name: 'muteTiming' },
+  '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withName(value): { name: value },
+  '#withTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervals(value): { time_intervals: (if std.isArray(value)
+                                               then value
+                                               else [value]) },
+  '#withTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withTimeIntervalsMixin(value): { time_intervals+: (if std.isArray(value)
+                                                     then value
+                                                     else [value]) },
+  time_intervals+:
+    {
+      '#': { help: '', name: 'time_intervals' },
+      '#withDaysOfMonth': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonth(value): { days_of_month: (if std.isArray(value)
+                                                then value
+                                                else [value]) },
+      '#withDaysOfMonthMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDaysOfMonthMixin(value): { days_of_month+: (if std.isArray(value)
+                                                      then value
+                                                      else [value]) },
+      '#withLocation': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withLocation(value): { location: value },
+      '#withMonths': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonths(value): { months: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+      '#withMonthsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withMonthsMixin(value): { months+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+      '#withTimes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimes(value): { times: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withTimesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withTimesMixin(value): { times+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      times+:
+        {
+          '#': { help: '', name: 'times' },
+          '#withEndMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withEndMinute(value): { EndMinute: value },
+          '#withStartMinute': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+          withStartMinute(value): { StartMinute: value },
+        },
+      '#withWeekdays': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdays(value): { weekdays: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+      '#withWeekdaysMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withWeekdaysMixin(value): { weekdays+: (if std.isArray(value)
+                                              then value
+                                              else [value]) },
+      '#withYears': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYears(value): { years: (if std.isArray(value)
+                                  then value
+                                  else [value]) },
+      '#withYearsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withYearsMixin(value): { years+: (if std.isArray(value)
+                                        then value
+                                        else [value]) },
+    },
+}

--- a/gen/grafonnet-v9.5.0/raw/alerting/notificationPolicy.libsonnet
+++ b/gen/grafonnet-v9.5.0/raw/alerting/notificationPolicy.libsonnet
@@ -1,0 +1,84 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.notificationPolicy', name: 'notificationPolicy' },
+  '#withContinue': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+  withContinue(value=true): { continue: value },
+  '#withGroupBy': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupBy(value): { group_by: (if std.isArray(value)
+                                   then value
+                                   else [value]) },
+  '#withGroupByMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withGroupByMixin(value): { group_by+: (if std.isArray(value)
+                                         then value
+                                         else [value]) },
+  '#withGroupInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupInterval(value): { group_interval: value },
+  '#withGroupWait': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withGroupWait(value): { group_wait: value },
+  '#withMatch': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatch(value): { match: value },
+  '#withMatchMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'Deprecated. Remove before v1.0 release.' } },
+  withMatchMixin(value): { match+: value },
+  '#withMatchRe': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchRe(value): { match_re: value },
+  '#withMatchReMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'MatchRegexps represents a map of Regexp.' } },
+  withMatchReMixin(value): { match_re+: value },
+  '#withMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchers(value): { matchers: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  '#withMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withMatchersMixin(value): { matchers+: (if std.isArray(value)
+                                          then value
+                                          else [value]) },
+  matchers+:
+    {
+      '#': { help: '', name: 'matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withMuteTimeIntervals': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervals(value): { mute_time_intervals: (if std.isArray(value)
+                                                        then value
+                                                        else [value]) },
+  '#withMuteTimeIntervalsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withMuteTimeIntervalsMixin(value): { mute_time_intervals+: (if std.isArray(value)
+                                                              then value
+                                                              else [value]) },
+  '#withObjectMatchers': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchers(value): { object_matchers: (if std.isArray(value)
+                                                 then value
+                                                 else [value]) },
+  '#withObjectMatchersMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: 'Matchers is a slice of Matchers that is sortable, implements Stringer, and\nprovides a Matches method to match a LabelSet against all Matchers in the\nslice. Note that some users of Matchers might require it to be sorted.' } },
+  withObjectMatchersMixin(value): { object_matchers+: (if std.isArray(value)
+                                                       then value
+                                                       else [value]) },
+  object_matchers+:
+    {
+      '#': { help: '', name: 'object_matchers' },
+      '#withName': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withName(value): { Name: value },
+      '#withType': { 'function': { args: [{ default: null, enums: ['=', '!=', '=~', '!~'], name: 'value', type: 'string' }], help: 'MatchType is an enum for label matching types.' } },
+      withType(value): { Type: value },
+      '#withValue': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withValue(value): { Value: value },
+    },
+  '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withProvenance(value): { provenance: value },
+  '#withReceiver': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withReceiver(value): { receiver: value },
+  '#withRepeatInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withRepeatInterval(value): { repeat_interval: value },
+  '#withRoutes': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutes(value): { routes: (if std.isArray(value)
+                                then value
+                                else [value]) },
+  '#withRoutesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRoutesMixin(value): { routes+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+}

--- a/gen/grafonnet-v9.5.0/raw/alerting/ruleGroup.libsonnet
+++ b/gen/grafonnet-v9.5.0/raw/alerting/ruleGroup.libsonnet
@@ -1,0 +1,89 @@
+// This file is generated, do not manually edit.
+{
+  '#': { help: 'grafonnet.alerting.ruleGroup', name: 'ruleGroup' },
+  '#withFolderUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withFolderUid(value): { folderUid: value },
+  '#withInterval': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+  withInterval(value): { interval: value },
+  '#withRules': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRules(value): { rules: (if std.isArray(value)
+                              then value
+                              else [value]) },
+  '#withRulesMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+  withRulesMixin(value): { rules+: (if std.isArray(value)
+                                    then value
+                                    else [value]) },
+  rules+:
+    {
+      '#': { help: '', name: 'rules' },
+      '#withAnnotations': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotations(value): { annotations: value },
+      '#withAnnotationsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withAnnotationsMixin(value): { annotations+: value },
+      '#withCondition': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withCondition(value): { condition: value },
+      '#withData': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withData(value): { data: (if std.isArray(value)
+                                then value
+                                else [value]) },
+      '#withDataMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'array' }], help: '' } },
+      withDataMixin(value): { data+: (if std.isArray(value)
+                                      then value
+                                      else [value]) },
+      data+:
+        {
+          '#': { help: '', name: 'data' },
+          '#withDatasourceUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: "Grafana data source unique identifier; it should be '__expr__' for a Server Side Expression operation." } },
+          withDatasourceUid(value): { datasourceUid: value },
+          '#withModel': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModel(value): { model: value },
+          '#withModelMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'JSON is the raw JSON query and includes the above properties as well as custom properties.' } },
+          withModelMixin(value): { model+: value },
+          '#withQueryType': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'QueryType is an optional identifier for the type of query.\nIt can be used to distinguish different types of queries.' } },
+          withQueryType(value): { queryType: value },
+          '#withRefId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: 'RefID is the unique identifier of the query, set by the frontend call.' } },
+          withRefId(value): { refId: value },
+          '#withRelativeTimeRange': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRange(value): { relativeTimeRange: value },
+          '#withRelativeTimeRangeMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: 'RelativeTimeRange is the per query start and end time\nfor requests.' } },
+          withRelativeTimeRangeMixin(value): { relativeTimeRange+: value },
+          relativeTimeRange+:
+            {
+              '#withFrom': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+              withFrom(value): { relativeTimeRange+: { from: value } },
+              '#withTo': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+              withTo(value): { relativeTimeRange+: { to: value } },
+            },
+        },
+      '#withExecErrState': { 'function': { args: [{ default: null, enums: ['Alerting', 'Error', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withExecErrState(value): { execErrState: value },
+      '#withFolderUID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withFolderUID(value): { folderUID: value },
+      '#withFor': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: 'Duration is a type used for marshalling durations.' } },
+      withFor(value): { 'for': value },
+      '#withId': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withId(value): { id: value },
+      '#withIsPaused': { 'function': { args: [{ default: true, enums: null, name: 'value', type: 'boolean' }], help: '' } },
+      withIsPaused(value=true): { isPaused: value },
+      '#withLabels': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabels(value): { labels: value },
+      '#withLabelsMixin': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'object' }], help: '' } },
+      withLabelsMixin(value): { labels+: value },
+      '#withNoDataState': { 'function': { args: [{ default: null, enums: ['Alerting', 'NoData', 'OK'], name: 'value', type: 'string' }], help: '' } },
+      withNoDataState(value): { noDataState: value },
+      '#withOrgID': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'integer' }], help: '' } },
+      withOrgID(value): { orgID: value },
+      '#withProvenance': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withProvenance(value): { provenance: value },
+      '#withRuleGroup': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withRuleGroup(value): { ruleGroup: value },
+      '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withTitle(value): { title: value },
+      '#withUid': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUid(value): { uid: value },
+      '#withUpdated': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+      withUpdated(value): { updated: value },
+    },
+  '#withTitle': { 'function': { args: [{ default: null, enums: null, name: 'value', type: 'string' }], help: '' } },
+  withTitle(value): { title: value },
+}

--- a/generator/alerting.libsonnet
+++ b/generator/alerting.libsonnet
@@ -1,0 +1,243 @@
+local j = import 'github.com/Duologic/jsonnet-libsonnet/main.libsonnet';
+local crdsonnet = import 'github.com/crdsonnet/crdsonnet/crdsonnet/main.libsonnet';
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+local refactor = import './refactor.libsonnet';
+local utils = import './utils.libsonnet';
+
+{
+  local root = self,
+
+  render(schemas):
+    local files = self.getFilesForSpec(schemas);
+    { 'alerting.libsonnet': root.alertingIndex(files.clean) }
+    + {
+      [file.path]: file.content
+      for type in std.objectFields(files)
+      for file in files[type]
+    },
+
+  // `name` matches the schema name
+  // `displayName` is how we want to show it in Grafonnet, matches GUI
+  schemas: [
+    {
+      name: 'EmbeddedContactPoint',
+      displayName: 'contactPoint',
+    },
+    {
+      name: 'Route',
+      displayName: 'notificationPolicy',
+    },
+    {
+      name: 'MuteTimeInterval',
+      displayName: 'muteTiming',
+    },
+    {
+      name: 'AlertRuleGroup',
+      displayName: 'ruleGroup',
+    },
+    {
+      name: 'NotificationTemplate',
+      displayName: 'messageTemplate',
+    },
+  ],
+
+  getFilesForSpec(spec):
+    std.foldl(
+      function(acc, schema)
+        local raw = {
+          title: schema.displayName,
+          path: 'raw/alerting/' + schema.displayName + '.libsonnet',
+          content: root.generateRawLib(schema.name, schema.displayName, spec),
+        };
+        acc + {
+          raw+:
+            (if schema.displayName in root.structure
+             then [raw]
+             else []),
+          clean+:
+            (if schema.displayName in root.structure
+             then [{
+               title: schema.displayName,
+               path: 'clean/alerting/' + schema.displayName + '.libsonnet',
+               content: root.generateCleanLib(schema.name, schema.displayName, spec),
+             }]
+             else [raw]),
+        },
+      root.schemas,
+      {}
+    ),
+
+  generateRawLib(name, displayName, spec):
+    local ast =
+      utils.unwrapFromCRDsonnet(
+        crdsonnet.openapi.render(
+          name,
+          spec.components.schemas[name],
+          spec,
+          refactor.ASTProcessor,
+          addNewFunction=false,
+        ),
+        name
+      );
+
+    utils.addDoc(
+      ast,
+      displayName,
+      'alerting.'
+    ).toString(break='\n'),
+
+  generateCleanLib(name, displayName, spec):
+    local ast =
+      utils.unwrapFromCRDsonnet(
+        crdsonnet.openapi.render(
+          name,
+          spec.components.schemas[name],
+          spec,
+          refactor.ASTProcessor,
+          addNewFunction=false,
+        ),
+        name
+      );
+
+    local structure = std.get(root.structure, displayName, default={});
+
+    local newAST =
+      if 'groupings' in structure
+         || 'copy' in structure
+      then
+        refactor.refactor(
+          ast,
+          std.get(structure, 'groupings', {}),
+          std.get(structure, 'copy', [])
+        )
+      else ast;
+
+    utils.addDoc(
+      newAST,
+      displayName,
+      'alerting.'
+    ).toString(break='\n')
+    + (if 'custom' in structure
+       then
+         '\n +'
+         + j.parenthesis(
+           j.importF('../../custom/' + structure.custom),
+         ).toString(break='\n')
+       else ''),
+
+  alertingIndex(files):
+    j.object.members(
+      [
+        j.field.field(
+          j.fieldname.string('#'),
+          j.literal(  // render docsonnet as literal to avoid docsonnet dependency
+            d.package.newSub(
+              'alerting',
+              'grafonnet.alerting'
+            ),
+          ),
+          nobreak=true,
+        ),
+      ]
+      + [
+        j.field.field(
+          j.fieldname.string(file.title),
+          j.importF(file.path),
+          nobreak=true,
+        )
+        for file in files
+      ]
+    ).toString(break='\n'),
+
+  structure: {
+    contactPoint: {
+      custom: 'alerting/contactPoint.libsonnet',
+    },
+    notificationPolicy: {
+      custom: 'alerting/notificationPolicy.libsonnet',
+      groupings: {
+        '.': [
+          'withContinue',
+          'withGroupInterval',
+          'withGroupWait',
+          'withRepeatInterval',
+          'withGroupBy',
+          'withGroupByMixin',
+          'withMatchers',
+          'withMatchersMixin',
+          'withMuteTimeIntervals',
+          'withMuteTimeIntervalsMixin',
+
+          // Renamed in custom
+          'withReceiver',  // withContactPoint
+          'withRoutes',  // withPolicies
+          'withRoutesMixin',  // withPoliciesMixin
+        ],
+      },
+
+      copy: [
+        { from: 'matchers', to: 'matcher' },
+      ],
+    },
+    muteTiming: {
+      custom: 'alerting/muteTiming.libsonnet',
+      groupings: {
+        '.': [
+          'withName',
+          'withTimeIntervals',
+          'withTimeIntervalsMixin',
+        ],
+      },
+      copy: [
+        { from: 'time_intervals', to: 'interval' },
+      ],
+    },
+    ruleGroup: {
+      custom: 'alerting/ruleGroup.libsonnet',
+      groupings: {
+        '.': [
+          'withFolderUid',
+          'withInterval',
+          'withRules',
+          'withRulesMixin',
+          'withTitle',  // rename to withName
+        ],
+        rule: [
+          'rules.withAnnotations',
+          'rules.withAnnotationsMixin',
+          'rules.withCondition',
+          'rules.withData',
+          'rules.withDataMixin',
+          'rules.withExecErrState',
+          'rules.withFor',
+          'rules.withIsPaused',
+          'rules.withLabels',
+          'rules.withLabelsMixin',
+          'rules.withNoDataState',
+          'rules.withTitle',  // rename to withName
+
+          // Given by parent object, may be read-only!?
+          //'rules.withFolderUID',
+          //'rules.withId',
+          //'rules.withOrgID',
+          //'rules.withProvenance',
+          //'rules.withRuleGroup',
+          //'rules.withUid',
+          //'rules.withUpdated',
+        ],
+      },
+      copy: [
+        { from: 'rules.data', to: 'rule.data' },
+      ],
+    },
+    messageTemplate: {
+      groupings: {
+        '.': [
+          'withName',
+          'withTemplate',
+        ],
+      },
+    },
+  },
+}

--- a/generator/core.libsonnet
+++ b/generator/core.libsonnet
@@ -149,6 +149,11 @@ local utils = import './utils.libsonnet';
           j.importF('custom/util/main.libsonnet'),
           nobreak=true,
         ),
+        j.field.field(
+          j.fieldname.id('alerting'),
+          j.importF('alerting.libsonnet'),
+          nobreak=true,
+        ),
       ]
     ).toString(break='\n'),
 

--- a/generator/main.libsonnet
+++ b/generator/main.libsonnet
@@ -1,16 +1,21 @@
+local alerting = import './alerting.libsonnet';
 local core = import './core.libsonnet';
 local panel = import './panel.libsonnet';
 local query = import './query.libsonnet';
 local row = import './row.libsonnet';
+
+local spec = import './spec.libsonnet';
 local utils = import './utils.libsonnet';
 
-function(version, schemas)
+function(version, schemas, openapiSpec)
   local processedSchemas = utils.processSchemas(version, schemas);
+  local processedSpec = spec.process(openapiSpec);
   local files =
     core.render(version, processedSchemas.core)
     + panel.render(processedSchemas.panel)
     + query.render(processedSchemas.query)
-    + row.render(processedSchemas.row);
+    + row.render(processedSchemas.row)
+    + alerting.render(processedSpec);
   {
     ['grafonnet-' + version + '/' + file]:
       '// This file is generated, do not manually edit.\n'

--- a/generator/spec.libsonnet
+++ b/generator/spec.libsonnet
@@ -1,0 +1,85 @@
+{
+  // Fix a few issues in the openapi spec so it renders properly, see individual function descriptions for more details.
+  process(spec):
+    self.renameTitleToDescription(spec)
+    + self.addIsPausedToProvisionedAlertRule()
+    + self.removeRecursiveRefOnRoute()
+    + self.fixMatchType(),
+
+  // the OpenAPI schema currently holds a number of `title` fields that contain a description of a parameter, this is used for godoc comments. This lacks standardisation upstream but should dissapear over time. In mean time we'll merge it here with `description` so it shows up in Grafonnet docs.
+  renameTitleToDescription(spec):
+    local schemas = spec.components.schemas;
+    spec + {
+      components+: {
+        schemas+:
+          std.foldl(
+            function(acc, k)
+              acc + {
+                [k]: schemas[k] + {
+                  description:
+                    std.join(
+                      '\n\n',
+                      std.prune([
+                        std.get(schemas[k], 'title', null),
+                        std.get(schemas[k], 'description', null),
+                      ])
+                    ),
+                },
+              },
+            std.objectFields(schemas),
+            {}
+          ),
+      },
+    },
+
+  // Add isPaused to ProvisionedAlertRule, this is missing in v9.4.0
+  addIsPausedToProvisionedAlertRule(): {
+    components+: {
+      schemas+: {
+        ProvisionedAlertRule+: {
+          properties+:
+            if !std.objectHas(super.properties, 'isPaused')
+            then {
+              isPaused+:
+                { type: 'boolean' },
+            }
+            else {},
+        },
+      },
+    },
+  },
+
+  // Remove recursive $ref on route to prevent infinite recursion.
+  removeRecursiveRefOnRoute(): {
+    components+: {
+      schemas+: {
+        Route+: {
+          properties+: {
+            routes+:
+              { items: { type: 'object' } },
+          },
+        },
+      },
+    },
+  },
+
+  // Fix matchType if type is wrong.
+  fixMatchType(): {
+    components+: {
+      schemas+: {
+        MatchType+:
+          if super.MatchType.type == 'integer'
+          then {
+            type: 'string',
+            enum: [
+              '=',
+              '!=',
+              '=~',
+              '!~',
+            ],
+          }
+          else {},
+      },
+    },
+  },
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -20,6 +20,7 @@ cp -r "${REPO_DIR}/generator" generator
 cp -r "${REPO_DIR}/generator/jsonnetfile.lock.json" .
 jb install
 jb install "github.com/grafana/grok/jsonnet/${VERSION}@main"
+jb install "github.com/grafana/grafana/public@${VERSION}"
 jb install ./generator
 
 OUT_DIR="${REPO_DIR}/gen"
@@ -35,6 +36,7 @@ mapfile -t FILES < <(
         -S -c -m "${OUT_DIR}" \
         --tla-str version="${VERSION}" \
         --tla-code-file schemas="github.com/grafana/grok/jsonnet/${VERSION}/imports.libsonnet" \
+        --tla-code-file openapiSpec="github.com/grafana/grafana/public/openapi3.json" \
         -e "(import 'generator/main.libsonnet')"
     )
 


### PR DESCRIPTION
Fixes #69

This PR provides an interface to create [Alerting provisioning resources](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/) with Grafonnet. I personally don't know if we have a client that can actually do something with these JSON resources but at least we have one part of the puzzle this way.

The Grafonnet API is modelled after the [Terraform provider resources](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/notification_policy). The `contactPoint` schema is under development so we can't offer that in Grafonnet properly yet.

The schema's for these resources come from the Grafana OpenAPI spec, this opens the door to add more resources that are described in this specification.

As always I tend to make this reviewable commit-by-commit. First commit is the actual code for the generator, the other two are generating the code and docs.