### PR TITLE
Adding maxPerRow for all panels and repeatDirection for row panel

### DIFF
--- a/custom/row.libsonnet
+++ b/custom/row.libsonnet
@@ -3,9 +3,15 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 {
   '#new':: d.func.new(
     'Creates a new row panel with a title.',
-    args=[d.arg('title', d.T.string)]
+    args=[
+      d.arg('title', d.T.string),
+      d.arg('maxPerRow', d.T.number),
+      d.arg('repeatDirection', d.T.string),
+    ]
   ),
-  new(title):
+  new(title, maxPerRow, repeatDirection):
     self.withTitle(title)
+    + self.withMaxPerRow(maxPerRow)
+    + self.withRepeatDirection(repeatDirection)
     + self.withType(),
 }


### PR DESCRIPTION
These two attributes are required for below reasons.
* **maxPerRow:** To limit on the max repeating panels in a row.
* **repeatDirection:** To allow repeat direction either "h" or "v" for a row panel.