### PR TITLE
Use general instead of string interpolation in example

### DIFF
--- a/examples/redMethod/lib/redDashboard/queries/prometheus.libsonnet
+++ b/examples/redMethod/lib/redDashboard/queries/prometheus.libsonnet
@@ -68,7 +68,7 @@ local g = import 'g.libsonnet';
       prometheusQuery.new(
         '$' + self.variables.datasource.name,
         |||
-          histogram_quantile(%s,
+          histogram_quantile(%0.4g,
             sum by (le) (
               rate(request_duration_seconds_bucket{%s}[$__rate_interval])
             )

--- a/examples/redMethod/output.json
+++ b/examples/redMethod/output.json
@@ -84,7 +84,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "histogram_quantile(0.98999999999999999,\n  sum by (le) (\n    rate(request_duration_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\",job=~\".*/faro-api\"}[$__rate_interval])\n  )\n) * 1e3\n",
+               "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    rate(request_duration_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\",job=~\".*/faro-api\"}[$__rate_interval])\n  )\n) * 1e3\n",
                "legendFormat": "99th Percentile"
             },
             {
@@ -181,7 +181,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "histogram_quantile(0.98999999999999999,\n  sum by (le) (\n    rate(request_duration_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\",job=~\".*/faro-collector\"}[$__rate_interval])\n  )\n) * 1e3\n",
+               "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    rate(request_duration_seconds_bucket{cluster=\"$cluster\",namespace=\"$namespace\",job=~\".*/faro-collector\"}[$__rate_interval])\n  )\n) * 1e3\n",
                "legendFormat": "99th Percentile"
             },
             {


### PR DESCRIPTION
The generated dashboard shows a quantile of '0.98999999999999999' (99/100) instead of a nicer 0.99 (https://github.com/grafana/grafonnet/blob/bb2afaffbcefeae1035cd691ab06a486e0022002/examples/redMethod/output.json#L87).  
By changing the interpolation from string (%s) to general (%g) this is more correct (see https://docs.python.org/3/library/string.html#format-specification-mini-language for %g).

It also leaves 0.5 to 1 decimal, and 0.99 to 2, while using %f would format 0.5 as 0.50.

