### PR TITLE
feat(custom): add helpers for dealing with panel IDs

### DIFF
--- a/custom/dashboard.libsonnet
+++ b/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/custom/util/panel.libsonnet
+++ b/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/custom/util/panel.libsonnet
+++ b/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/docs/API/util.md
+++ b/docs/API/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/docs/API/util.md
+++ b/docs/API/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v10.0.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v10.0.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v10.0.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.0.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v10.0.0/docs/util.md
+++ b/gen/grafonnet-v10.0.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v10.0.0/docs/util.md
+++ b/gen/grafonnet-v10.0.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v10.1.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v10.1.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v10.1.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.1.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v10.1.0/docs/util.md
+++ b/gen/grafonnet-v10.1.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v10.1.0/docs/util.md
+++ b/gen/grafonnet-v10.1.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v10.2.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v10.2.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v10.2.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.2.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v10.2.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.2.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v10.2.0/docs/util.md
+++ b/gen/grafonnet-v10.2.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v10.2.0/docs/util.md
+++ b/gen/grafonnet-v10.2.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v10.3.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v10.3.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v10.3.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.3.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v10.3.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.3.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v10.3.0/docs/util.md
+++ b/gen/grafonnet-v10.3.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v10.3.0/docs/util.md
+++ b/gen/grafonnet-v10.3.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v10.4.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v10.4.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v10.4.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.4.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v10.4.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v10.4.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v10.4.0/docs/util.md
+++ b/gen/grafonnet-v10.4.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v10.4.0/docs/util.md
+++ b/gen/grafonnet-v10.4.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v9.4.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v9.4.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v9.4.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v9.4.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v9.4.0/docs/util.md
+++ b/gen/grafonnet-v9.4.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v9.4.0/docs/util.md
+++ b/gen/grafonnet-v9.4.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/gen/grafonnet-v9.5.0/custom/dashboard.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/dashboard.libsonnet
@@ -13,13 +13,19 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
     + self.time.withFrom('now-6h')
     + self.time.withTo('now'),
 
-  withPanels(value): {
+  withPanels(value, setPanelIDs=true): {
     _panels:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
-  withPanelsMixin(value): {
+  withPanelsMixin(value, setPanelIDs=true): {
     _panels+:: if std.isArray(value) then value else [value],
-    panels: util.panel.setPanelIDs(self._panels),
+    panels:
+      if setPanelIDs
+      then util.panel.setPanelIDs(self._panels)
+      else self._panels,
   },
 
   graphTooltip+: {

--- a/gen/grafonnet-v9.5.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/util/panel.libsonnet
@@ -4,13 +4,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 {
   local this = self,
 
+  // used in ../dashboard.libsonnet
   '#setPanelIDs':: d.func.new(
     |||
-      `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-      `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-      experience.
+      `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-      used in ../dashboard.libsonnet
+      `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
     |||,
     args=[
       d.arg('panels', d.T.array),
@@ -56,6 +55,38 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
         { index: start, panels: [] }
       ).panels;
     infunc(panels),
+
+  '#getPanelIDs':: d.func.new(
+    |||
+      `getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  getPanelIDs(panels):
+    std.flattenArrays(
+      std.map(
+        function(panel)
+          [panel.id]
+          + (if panel.type == 'row'
+             then this.getPanelIDs(std.get(panel, 'panels', []))
+             else []),
+        panels
+      )
+    ),
+
+  '#validatePanelIDs':: d.func.new(
+    |||
+      `validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
+    |||,
+    args=[
+      d.arg('panels', d.T.array),
+    ]
+  ),
+  validatePanelIDs(panels):
+    local ids = this.getPanelIDs(panels);
+    std.set(ids) == std.sort(ids),
 
   '#sanitizePanel':: d.func.new(
     |||

--- a/gen/grafonnet-v9.5.0/custom/util/panel.libsonnet
+++ b/gen/grafonnet-v9.5.0/custom/util/panel.libsonnet
@@ -14,9 +14,10 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
     |||,
     args=[
       d.arg('panels', d.T.array),
+      d.arg('overrideExistingIDs', d.T.bool, default=true),
     ]
   ),
-  setPanelIDs(panels):
+  setPanelIDs(panels, overrideExistingIDs=true):
     local infunc(panels, start=1) =
       std.foldl(
         function(acc, panel)
@@ -31,7 +32,12 @@ local xtd = import 'github.com/jsonnet-libs/xtd/main.libsonnet';
 
             panels+: [
               panel
-              + { id: acc.index }
+              + (
+                if overrideExistingIDs
+                   || std.get(panel, 'id', null) == null
+                then { id: acc.index }
+                else {}
+              )
               + (
                 if panel.type == 'row'
                    && 'panels' in panel

--- a/gen/grafonnet-v9.5.0/docs/util.md
+++ b/gen/grafonnet-v9.5.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
   * [`fn mapToRows(func, panels)`](#fn-panelmaptorows)
@@ -21,6 +22,7 @@ Helper functions that work well with Grafonnet.
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
+  * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
 * [`obj string`](#obj-string)
   * [`fn slugify(string)`](#fn-stringslugify)
 
@@ -104,6 +106,18 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.getPanelIDs
+
+```jsonnet
+panel.getPanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`getPanelIDs` returns an array with all panel IDs including IDs from panels in rows.
 
 #### fn panel.getPanelsBeforeNextRow
 
@@ -214,11 +228,9 @@ PARAMETERS:
 * **overrideExistingIDs** (`bool`)
    - default value: `true`
 
-`setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
-`dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent
-experience.
+`setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
-used in ../dashboard.libsonnet
+`overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
 
 #### fn panel.sortPanelsByXY
 
@@ -243,6 +255,18 @@ PARAMETERS:
 * **rowPanel** (`object`)
 
 `sortPanelsInRow` applies `sortPanelsByXY` on the panels in a rowPanel.
+
+#### fn panel.validatePanelIDs
+
+```jsonnet
+panel.validatePanelIDs(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`validatePanelIDs` validates returns `false` if there are duplicate panel IDs in `panels`.
 
 ### obj string
 

--- a/gen/grafonnet-v9.5.0/docs/util.md
+++ b/gen/grafonnet-v9.5.0/docs/util.md
@@ -18,7 +18,7 @@ Helper functions that work well with Grafonnet.
   * [`fn normalizeYInRow(rowPanel)`](#fn-panelnormalizeyinrow)
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
-  * [`fn setPanelIDs(panels)`](#fn-panelsetpanelids)
+  * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
 * [`obj string`](#obj-string)
@@ -205,12 +205,14 @@ The default values for x,y,h,w are only applied if not already set.
 #### fn panel.setPanelIDs
 
 ```jsonnet
-panel.setPanelIDs(panels)
+panel.setPanelIDs(panels, overrideExistingIDs=true)
 ```
 
 PARAMETERS:
 
 * **panels** (`array`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
 
 `setPanelIDs` ensures that all `panels` have a unique ID, this functions is used in
 `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent

--- a/test/util_test.jsonnet
+++ b/test/util_test.jsonnet
@@ -91,6 +91,93 @@ test.new(std.thisFile)
     )
   )
 )
++ (
+  local panelsWithIntentionalManualIDs = [
+    { type: 'timeseries' },
+    { type: 'row' },
+    { type: 'timeseries' },
+    { type: 'stat' },
+    {
+      type: 'row',
+      panels: [
+        { type: 'timeseries' },
+        { type: 'stat' },
+        { type: 'table', id: 500 },
+        { type: 'timeseries' },
+      ],
+    },
+    { type: 'table' },
+    { type: 'timeseries' },
+  ];
+
+  local expected = [
+    { type: 'timeseries', id: 1 },
+    { type: 'row', id: 2 },
+    { type: 'timeseries', id: 3 },
+    { type: 'stat', id: 4 },
+    {
+      type: 'row',
+      id: 5,
+      panels: [
+        { type: 'timeseries', id: 6 },
+        { type: 'stat', id: 7 },
+        { type: 'table', id: 500 },
+        { type: 'timeseries', id: 9 },
+      ],
+    },
+    { type: 'table', id: 10 },
+    { type: 'timeseries', id: 11 },
+  ];
+
+  local actual =
+    util.panel.setPanelIDs(
+      panelsWithIntentionalManualIDs,
+      overrideExistingIDs=false,
+    );
+
+  test.case.new(
+    name='Panel IDs are sanitized without overriding existing IDs',
+    test=test.expect.eqDiff(
+      actual=actual,
+      expected=expected,
+    )
+  )
+  + test.case.new(
+    name='Panel IDs validation - success',
+    test=test.expect.eqDiff(
+      actual=util.panel.validatePanelIDs(expected),
+      expected=true,
+    )
+  )
+)
++ (
+  local panelWithDuplicateIDs = [
+    { type: 'timeseries', id: 1 },
+    { type: 'row', id: 2 },
+    { type: 'timeseries', id: 3 },
+    { type: 'stat', id: 4 },
+    {
+      type: 'row',
+      id: 5,
+      panels: [
+        { type: 'timeseries', id: 6 },
+        { type: 'stat', id: 7 },
+        { type: 'table', id: 3 },
+        { type: 'timeseries', id: 9 },
+      ],
+    },
+    { type: 'table', id: 10 },
+    { type: 'timeseries', id: 11 },
+  ];
+
+  test.case.new(
+    name='Panel IDs validation - failure',
+    test=test.expect.eqDiff(
+      actual=util.panel.validatePanelIDs(panelWithDuplicateIDs),
+      expected=false,
+    )
+  )
+)
 
 // util.dashboard.getOptionsForCustomQuery
 + (


### PR DESCRIPTION
This PR adds a few functions and parameters so users can build their own panel ID management.

This could help resolve #176, it doesn't bring the `-- Dashboard --` data source but could opens the possibility to statically define panel IDs so they can be referenced properly.