### PR TITLE
feat(util): dedupe query targets into shared queries

### DIFF
--- a/docs/API/util.md
+++ b/docs/API/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn dedupeQueryTargets(panels)`](#fn-paneldedupequerytargets)
   * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
@@ -20,6 +21,8 @@ Helper functions that work well with Grafonnet.
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
+  * [`fn setRefIDs(panel, overrideExistingIDs=true)`](#fn-panelsetrefids)
+  * [`fn setRefIDsOnPanels(panels)`](#fn-panelsetrefidsonpanels)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
   * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
@@ -106,6 +109,20 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.dedupeQueryTargets
+
+```jsonnet
+panel.dedupeQueryTargets(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`dedupeQueryTargets` dedupes the query targets in a set of panels and replaces the duplicates with a ['shared query'](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/share-query/). Sharing query results across panels reduces the number of queries made to your data source, which can improve the performance of your dashboard.
+
+This function requires that the query targets have `refId` set, `setRefIDs` and `setRefIDsOnPanels` can help with that.
 
 #### fn panel.getPanelIDs
 
@@ -231,6 +248,32 @@ PARAMETERS:
 `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
 `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
+
+#### fn panel.setRefIDs
+
+```jsonnet
+panel.setRefIDs(panel, overrideExistingIDs=true)
+```
+
+PARAMETERS:
+
+* **panel** (`object`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
+
+`setRefIDs` calculates the `refId` field for each target on a panel.
+
+#### fn panel.setRefIDsOnPanels
+
+```jsonnet
+panel.setRefIDsOnPanels(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`setRefIDsOnPanels` applies `setRefIDs on all `panels`.
 
 #### fn panel.sortPanelsByXY
 

--- a/gen/grafonnet-v11.0.0/docs/util.md
+++ b/gen/grafonnet-v11.0.0/docs/util.md
@@ -11,6 +11,7 @@ Helper functions that work well with Grafonnet.
   * [`fn wrapPanels(panels, panelWidth, panelHeight, startY)`](#fn-gridwrappanels)
 * [`obj panel`](#obj-panel)
   * [`fn calculateLowestYforPanel(panel, panels)`](#fn-panelcalculatelowestyforpanel)
+  * [`fn dedupeQueryTargets(panels)`](#fn-paneldedupequerytargets)
   * [`fn getPanelIDs(panels)`](#fn-panelgetpanelids)
   * [`fn getPanelsBeforeNextRow(panels)`](#fn-panelgetpanelsbeforenextrow)
   * [`fn groupPanelsInRows(panels)`](#fn-panelgrouppanelsinrows)
@@ -20,6 +21,8 @@ Helper functions that work well with Grafonnet.
   * [`fn resolveCollapsedFlagOnRows(panels)`](#fn-panelresolvecollapsedflagonrows)
   * [`fn sanitizePanel(panel, defaultX=0, defaultY=0, defaultHeight=8, defaultWidth=8)`](#fn-panelsanitizepanel)
   * [`fn setPanelIDs(panels, overrideExistingIDs=true)`](#fn-panelsetpanelids)
+  * [`fn setRefIDs(panel, overrideExistingIDs=true)`](#fn-panelsetrefids)
+  * [`fn setRefIDsOnPanels(panels)`](#fn-panelsetrefidsonpanels)
   * [`fn sortPanelsByXY(panels)`](#fn-panelsortpanelsbyxy)
   * [`fn sortPanelsInRow(rowPanel)`](#fn-panelsortpanelsinrow)
   * [`fn validatePanelIDs(panels)`](#fn-panelvalidatepanelids)
@@ -106,6 +109,20 @@ PARAMETERS:
 * **panels** (`array`)
 
 `calculateLowestYforPanel` calculates Y for a given `panel` from the `gridPos` of an array of `panels`. This function is used in `normalizeY`.
+
+#### fn panel.dedupeQueryTargets
+
+```jsonnet
+panel.dedupeQueryTargets(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`dedupeQueryTargets` dedupes the query targets in a set of panels and replaces the duplicates with a ['shared query'](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/share-query/). Sharing query results across panels reduces the number of queries made to your data source, which can improve the performance of your dashboard.
+
+This function requires that the query targets have `refId` set, `setRefIDs` and `setRefIDsOnPanels` can help with that.
 
 #### fn panel.getPanelIDs
 
@@ -231,6 +248,32 @@ PARAMETERS:
 `setPanelIDs` ensures that all `panels` have a unique ID, this function is used in `dashboard.withPanels` and `dashboard.withPanelsMixin` to provide a consistent experience.
 
 `overrideExistingIDs` can be set to not replace existing IDs, consider validating the IDs with `validatePanelIDs()` to ensure there are no duplicate IDs.
+
+#### fn panel.setRefIDs
+
+```jsonnet
+panel.setRefIDs(panel, overrideExistingIDs=true)
+```
+
+PARAMETERS:
+
+* **panel** (`object`)
+* **overrideExistingIDs** (`bool`)
+   - default value: `true`
+
+`setRefIDs` calculates the `refId` field for each target on a panel.
+
+#### fn panel.setRefIDsOnPanels
+
+```jsonnet
+panel.setRefIDsOnPanels(panels)
+```
+
+PARAMETERS:
+
+* **panels** (`array`)
+
+`setRefIDsOnPanels` applies `setRefIDs on all `panels`.
 
 #### fn panel.sortPanelsByXY
 


### PR DESCRIPTION
This PR adds a util function to dedupe query targets into ['shared queries'](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/share-query/), this could boost performance of dashboards that run the same query multiple times in different panels.

Rudimentary example:

```jsonnet
local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';

local sharedQuery1 =
  g.query.prometheus.new(
    'mimir',
    'query1',
  );

local sharedQuery2 =
  g.query.prometheus.new(
    'mimir',
    'query2',
  );

local panels =
  [
    g.panel.timeSeries.new('Panel 1')
    + g.panel.timeSeries.queryOptions.withTargets([
      sharedQuery1,
    ]),

    g.panel.timeSeries.new('Panel 2')
    + g.panel.timeSeries.queryOptions.withTargets([
      sharedQuery2,
      sharedQuery1, # This will get replaced.
    ]),
    g.panel.timeSeries.new('Panel 3')
    + g.panel.timeSeries.queryOptions.withTargets([
      sharedQuery2, # This will get replaced.
    ]),
  ];

g.dashboard.new('Dashboard')
+ g.dashboard.withPanels(
  std.foldl(
    function(panels, f) f(panels),
    // Apply these functions to the panels
    [
      g.util.panel.setPanelIDs,
      g.util.panel.setRefIDsOnPanels,
      g.util.panel.dedupeQueryTargets,  // Requires `refId` on targets and `id` on panels
    ],
    panels
  ),
  setPanelIDs=false,  // IDs set on inner function
)
```