### PR TITLE
securing github actions

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -7,11 +7,15 @@ on:
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,13 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install jsonnet
         run: |


### PR DESCRIPTION
Securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
